### PR TITLE
Add clone repository command with form

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,20 @@
       ]
     },
     {
+      "name": "clone-repository",
+      "title": "Clone Git Repository",
+      "description": "Clone a repository from SSH or HTTPS URL",
+      "mode": "view",
+      "arguments": [
+        {
+          "name": "url",
+          "placeholder": "Repository URL (SSH or HTTPS)",
+          "type": "text",
+          "required": false
+        }
+      ]
+    },
+    {
       "name": "manage-ai-message-prompts",
       "title": "Manage AI Message Prompts",
       "description": "Configure AI commit message prompt presets",

--- a/src/clone-repository.tsx
+++ b/src/clone-repository.tsx
@@ -1,0 +1,147 @@
+import { Action, ActionPanel, Form, Icon, useNavigation } from "@raycast/api";
+import { useCachedState } from "@raycast/utils";
+import React, { useEffect, useMemo, useState } from "react";
+import OpenRepository from "./open-repository";
+import { GitManager } from "./utils/git-manager";
+
+interface Arguments {
+  url?: string;
+}
+
+export default function CloneRepository({ arguments: args }: { arguments?: Arguments }) {
+  const { push } = useNavigation();
+
+  const [repoUrl, setRepoUrl] = useState<string>(args?.url || "");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Remember last used parent directory for future clones
+  const [cachedParentDir, setCachedParentDir] = useCachedState<string>(
+    "git-last-clone-parent-dir",
+    ""
+  );
+  const [parentDirectory, setParentDirectory] = useState<string[]>(
+    cachedParentDir ? [cachedParentDir] : []
+  );
+
+  // HTTPS optional credentials
+  const [httpsUsername, setHttpsUsername] = useState("");
+  const [httpsPassword, setHttpsPassword] = useState("");
+
+  useEffect(() => {
+    if (parentDirectory.length > 0) {
+      setCachedParentDir(parentDirectory[0]);
+    }
+  }, [parentDirectory, setCachedParentDir]);
+
+  const urlType: "https" | "ssh" | "invalid" | "empty" = useMemo(() => {
+    if (!repoUrl || repoUrl.trim() === "") return "empty";
+    if (/^https?:\/\//i.test(repoUrl.trim())) return "https";
+    if (/^ssh:\/\//i.test(repoUrl.trim())) return "ssh";
+    if (/^[\w.-]+@[^:]+:.+/.test(repoUrl.trim())) return "ssh"; // git@github.com:org/repo.git
+    return "invalid";
+  }, [repoUrl]);
+
+  const urlValidationError = useMemo(() => {
+    if (urlType === "empty") return undefined; // optional field
+    if (urlType === "invalid") return "Enter a valid SSH or HTTPS URL";
+    return undefined;
+  }, [urlType]);
+
+  const parentDirValidationError = useMemo(() => {
+    if (parentDirectory.length === 0) return "Required";
+    return undefined;
+  }, [parentDirectory]);
+
+  const handleSubmit = async () => {
+    if (urlType !== "https" && urlType !== "ssh") {
+      return; // Do nothing if URL is invalid or empty
+    }
+    if (parentDirectory.length === 0) {
+      return; // Required field
+    }
+
+    setIsSubmitting(true);
+    try {
+      const targetPath = await GitManager.cloneRepository({
+        url: repoUrl.trim(),
+        parentDirectory: parentDirectory[0],
+        httpsCredentials:
+          urlType === "https"
+            ? {
+                username: httpsUsername.trim() || undefined,
+                password: httpsPassword,
+              }
+            : undefined,
+      });
+
+      // On success open the repository view
+      push(<OpenRepository arguments={{ path: targetPath }} />);
+    } catch (_error) {
+      // Intentionally do nothing on failure as requested
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Form
+      navigationTitle="Clone Repository"
+      isLoading={isSubmitting}
+      enableDrafts
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Clone Repository" icon={Icon.Download} onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.TextField
+        id="url"
+        title="Repository URL"
+        placeholder="SSH or HTTPS URL"
+        value={repoUrl}
+        onChange={setRepoUrl}
+        error={urlValidationError}
+      />
+
+      <Form.FilePicker
+        id="parentDirectory"
+        title="Parent Directory"
+        value={parentDirectory}
+        onChange={setParentDirectory}
+        allowMultipleSelection={false}
+        canChooseDirectories
+        canChooseFiles={false}
+        error={parentDirValidationError}
+      />
+
+      {urlType === "https" && (
+        <>
+          <Form.Separator />
+          <Form.TextField
+            id="username"
+            title="Username (HTTPS)"
+            placeholder="Optional"
+            value={httpsUsername}
+            onChange={setHttpsUsername}
+          />
+          {/* Password is optional; leave blank to use credential helper */}
+          <Form.PasswordField
+            id="password"
+            title="Password (HTTPS)"
+            placeholder="Optional"
+            value={httpsPassword}
+            onChange={setHttpsPassword}
+          />
+        </>
+      )}
+
+      {urlType === "ssh" && (
+        <>
+          <Form.Separator />
+          <Form.Description text="Using SSH. Credentials are managed by your SSH agent (if configured)." />
+        </>
+      )}
+    </Form>
+  );
+}
+

--- a/src/utils/git-manager.ts
+++ b/src/utils/git-manager.ts
@@ -1168,6 +1168,67 @@ __REBASE_TODO__
   }
 
   /**
+   * Clone a repository from a remote URL into a parent directory.
+   * If credentials are provided for HTTPS, they will be embedded into the URL.
+   * For SSH, credentials are generally managed via ssh-agent and not passed here.
+   * Returns the absolute path of the cloned repository.
+   */
+  static async cloneRepository(options: {
+    url: string;
+    parentDirectory: string;
+    directoryName?: string;
+    httpsCredentials?: { username?: string; password?: string };
+    depth?: number;
+  }): Promise<string> {
+    const { url, parentDirectory, directoryName, httpsCredentials, depth } = options;
+
+    // Prepare URL with HTTPS basic auth if provided
+    let effectiveUrl = url.trim();
+    if (httpsCredentials && /^https?:\/\//i.test(effectiveUrl)) {
+      const parsed = new URL(effectiveUrl);
+      if (httpsCredentials.username) parsed.username = httpsCredentials.username;
+      if (httpsCredentials.password) parsed.password = httpsCredentials.password;
+      effectiveUrl = parsed.toString();
+    }
+
+    const inferDirName = (input: string): string => {
+      // HTTPS
+      if (/^https?:\/\//i.test(input)) {
+        try {
+          const u = new URL(input);
+          const last = u.pathname.split("/").filter(Boolean).pop() || "repo";
+          return last.replace(/\.git$/i, "");
+        } catch {
+          // fall through to generic parsing
+        }
+      }
+      // SSH scp-like: git@host:org/repo.git
+      const tail = input.includes("/") ? input.substring(input.lastIndexOf("/") + 1) : input;
+      const colonTail = tail.includes(":") ? tail.substring(tail.lastIndexOf(":") + 1) : tail;
+      return colonTail.replace(/\.git$/i, "");
+    };
+
+    const targetDir = directoryName
+      ? path.join(parentDirectory, directoryName)
+      : path.join(parentDirectory, inferDirName(effectiveUrl));
+
+    const git = simpleGit(
+      undefined,
+      {
+        errors: (error, _result) => error,
+      }
+    );
+
+    const cloneArgs: string[] = [];
+    if (typeof depth === "number" && depth > 0) {
+      cloneArgs.push("--depth", String(depth));
+    }
+
+    await git.clone(effectiveUrl, targetDir, cloneArgs);
+    return targetDir;
+  }
+
+  /**
    * Gets the default remote name (usually 'origin', but can be the first available remote).
    */
   async getDefaultRemote(): Promise<string> {


### PR DESCRIPTION
Add a new 'Clone Git Repository' command to allow users to clone repositories via a form, supporting SSH and HTTPS with optional credentials.

---
<a href="https://cursor.com/background-agent?bcId=bc-dbda1fd0-165e-47d0-ba54-8c20a74e0e3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dbda1fd0-165e-47d0-ba54-8c20a74e0e3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

