### PR TITLE
Customize repository open action with app picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,18 +36,10 @@
   ],
   "preferences": [
     {
-      "name": "defaultEditor",
-      "required": true,
-      "type": "appPicker",
-      "title": "Default Editor",
-      "default": "com.apple.finder",
-      "description": "The default editor to open files with (e.g. 'Visual Studio Code')"
-    },
-    {
       "name": "defaultTerminal",
       "required": true,
       "type": "appPicker",
-      "title": "Default Terminal",
+      "title": "Default Terminal\n(shift + ⌘ + T)",
       "default": "com.apple.Terminal",
       "description": "The default terminal app to open repository directory in (e.g. 'Terminal', 'Warp')"
     },
@@ -55,7 +47,8 @@
       "name": "externalGitClient",
       "required": true,
       "type": "appPicker",
-      "title": "External Git Client",
+      "title": "External Git Client\n(shift + ⌘ + G)",
+      "default": "com.apple.Terminal",
       "description": "The external git client to use for git commands (e.g. 'GitKraken')"
     },
     {
@@ -89,7 +82,7 @@
       "required": false,
       "type": "textfield",
       "title": "Max Branches to Load",
-      "default": "20",
+      "default": "80",
       "description": "Maximum number of branches to load in local and remote branches sections"
     },
     {

--- a/src/commands/views/CommitDiffView.tsx
+++ b/src/commands/views/CommitDiffView.tsx
@@ -179,6 +179,13 @@ function FileListItem({
               gitManager={gitManager}
               onRefresh={onRefresh}
             />
+            <FileRestoreAction
+              filePath={absolutePath}
+              before={true}
+              commit={commit.hash}
+              gitManager={gitManager}
+              onRefresh={onRefresh}
+            />
           </ActionPanel.Section>
           {navigationActions}
         </ActionPanel>

--- a/src/commands/views/CommitDiffView.tsx
+++ b/src/commands/views/CommitDiffView.tsx
@@ -277,15 +277,15 @@ function CommitNavigationActions({ onMoveToCommit }: { onMoveToCommit: (directio
   return (
     <ActionPanel.Section title="History">
       <Action
-        title="Move to Child Commit"
-        icon={Icon.ChevronUp}
-        onAction={() => onMoveToCommit("child")}
-        shortcut={{ modifiers: ["cmd"], key: "[" }}
-      />
-      <Action
         title="Move to Parent Commit"
         icon={Icon.ChevronDown}
         onAction={() => onMoveToCommit("parent")}
+        shortcut={{ modifiers: ["cmd"], key: "[" }}
+      />
+      <Action
+        title="Move to Child Commit"
+        icon={Icon.ChevronUp}
+        onAction={() => onMoveToCommit("child")}
         shortcut={{ modifiers: ["cmd"], key: "]" }}
       />
     </ActionPanel.Section>

--- a/src/commands/views/CommitDiffView.tsx
+++ b/src/commands/views/CommitDiffView.tsx
@@ -1,7 +1,7 @@
-import { ActionPanel, Action, List, Icon, Color } from "@raycast/api";
+import { ActionPanel, Action, List, Icon, Color, showToast, Toast } from "@raycast/api";
 import { useGitDiff } from "../../hooks/useGitDiff";
 import { GitManager } from "../../utils/git-manager";
-import { Commit, CommitFileChange } from "../../types";
+import { Commit, CommitFileChange, ListPagination } from "../../types";
 import {
   FileOpenAction,
   FileOpenWithAction,
@@ -17,20 +17,95 @@ import { existsSync } from "fs";
 import { join } from "path";
 
 interface CommitDiffViewProps {
-  commit: Commit;
+  index: number;
   gitManager: GitManager;
   navigationActions: React.ReactNode;
   onRefresh: () => void;
+  commits: Commit[];
+  pagination?: ListPagination;
+  onMoveToCommit: (commitHash: string) => void;
 }
 
-export function CommitDiffView({ commit, gitManager, navigationActions, onRefresh }: CommitDiffViewProps) {
+export function CommitDiffView({ index, gitManager, navigationActions, onRefresh, commits, onMoveToCommit, pagination }: CommitDiffViewProps) {
+  const [currentIndex, setCurrentIndex] = useState(index);
   const [isShowingDetail, setIsShowingDetail] = useState(false);
+
+  const switchToCommit = async (direction: ("parent" | "child")) => {
+    let nextIndex = currentIndex;
+    switch (direction) {
+      case "parent":
+        nextIndex = currentIndex + 1;
+        break;
+      case "child":
+        nextIndex = currentIndex - 1;
+        break;
+    }
+
+    if (nextIndex < 0) {
+      showToast({
+        style: Toast.Style.Failure,
+        title: "No more commits",
+        message: "This is the last commit in the repository.",
+      });
+      return;
+    }
+
+    if (nextIndex >= commits.length) {
+      pagination?.onLoadMore()
+
+      if (!pagination?.hasMore) {
+        showToast({
+          style: Toast.Style.Failure,
+          title: "No more commits",
+          message: "This is the last commit in the repository.",
+        });
+        return;
+      }
+
+      switchToCommit(direction);
+      return;
+    }
+
+    setCurrentIndex(nextIndex);
+    onMoveToCommit(commits[nextIndex].hash);
+  };
+
+  return (
+    <SpecificCommitDiffView
+      commit={commits[currentIndex]}
+      gitManager={gitManager}
+      navigationActions={navigationActions}
+      onRefresh={onRefresh}
+      onMoveToCommit={switchToCommit}
+      isShowingDetail={isShowingDetail}
+      setIsShowingDetail={setIsShowingDetail}
+    />
+  );
+}
+
+function SpecificCommitDiffView({
+  commit,
+  gitManager,
+  navigationActions,
+  onRefresh,
+  onMoveToCommit,
+  isShowingDetail,
+  setIsShowingDetail,
+}: {
+  commit: Commit,
+  gitManager: GitManager,
+  navigationActions: React.ReactNode,
+  onRefresh: () => void,
+  onMoveToCommit: (direction: ("parent" | "child")) => void
+  isShowingDetail: boolean,
+  setIsShowingDetail: (isShowingDetail: boolean) => void
+}) {
   const [selectedFilePath, setSelectedFilePath] = useState<string | null>(null);
   const { data: statsMap, isLoading } = usePromise(
     async (repoPath, commitHash) => {
       return await gitManager.getCommitFileStats(commitHash);
     },
-    [gitManager.repoPath, commit.hash],
+    [gitManager.repoPath, commit.hash]
   );
 
   const toggleDetail = () => {
@@ -53,7 +128,7 @@ export function CommitDiffView({ commit, gitManager, navigationActions, onRefres
             onAction={toggleDetail}
             shortcut={{ modifiers: ["cmd", "shift"], key: "d" }}
           />
-
+          <CommitNavigationActions onMoveToCommit={onMoveToCommit} />
           {navigationActions}
         </ActionPanel>
       }
@@ -78,6 +153,7 @@ export function CommitDiffView({ commit, gitManager, navigationActions, onRefres
               selectedFilePath={selectedFilePath}
               statsMap={statsMap}
               onRefresh={onRefresh}
+              onMoveToCommit={onMoveToCommit}
             />
           ))}
         </List.Section>
@@ -90,24 +166,26 @@ interface FileListItemProps {
   file: CommitFileChange;
   commit: Commit;
   gitManager: GitManager;
-  navigationActions: React.ReactNode;
   isShowingDetail: boolean;
   onToggleDetail: () => void;
   selectedFilePath: string | null;
   statsMap: Record<string, { insertions: number; deletions: number }> | undefined;
   onRefresh: () => void;
+  onMoveToCommit: (direction: ("parent" | "child")) => void;
+  navigationActions: React.ReactNode;
 }
 
 function FileListItem({
   file,
   commit,
   gitManager,
-  navigationActions,
   isShowingDetail,
   onToggleDetail,
   selectedFilePath,
   statsMap,
   onRefresh,
+  onMoveToCommit,
+  navigationActions,
 }: FileListItemProps) {
   // Create a unique identifier for each file item
   const fileId = `${file.path}-${commit.hash}`;
@@ -187,9 +265,29 @@ function FileListItem({
               onRefresh={onRefresh}
             />
           </ActionPanel.Section>
+          <CommitNavigationActions onMoveToCommit={onMoveToCommit} />
           {navigationActions}
         </ActionPanel>
       }
     />
+  );
+}
+
+function CommitNavigationActions({ onMoveToCommit }: { onMoveToCommit: (direction: ("parent" | "child")) => void }) {
+  return (
+    <ActionPanel.Section title="History">
+      <Action
+        title="Move to Child Commit"
+        icon={Icon.ChevronUp}
+        onAction={() => onMoveToCommit("child")}
+        shortcut={{ modifiers: ["cmd"], key: "[" }}
+      />
+      <Action
+        title="Move to Parent Commit"
+        icon={Icon.ChevronDown}
+        onAction={() => onMoveToCommit("parent")}
+        shortcut={{ modifiers: ["cmd"], key: "]" }}
+      />
+    </ActionPanel.Section>
   );
 }

--- a/src/commands/views/CommitsView.tsx
+++ b/src/commands/views/CommitsView.tsx
@@ -1,4 +1,4 @@
-import { ActionPanel, List, Icon, Action, Color } from "@raycast/api";
+import { ActionPanel, List, Icon, Action, Color, useNavigation } from "@raycast/api";
 import { getFavicon, useCachedState } from "@raycast/utils";
 import {
   CommitCheckoutAction,
@@ -28,15 +28,9 @@ import {
   replaceUrlPatternsWithLinks,
 } from "../../hooks/useUrlTracker";
 import "../../utils/date-utils";
-import { Commit, UrlTrackerConfig, BranchesState, Branch, DetachedHead, GitView } from "../../types";
+import { Commit, UrlTrackerConfig, BranchesState, Branch, DetachedHead, GitView, ListPagination } from "../../types";
 import { useMemo, useState } from "react";
 import { CommitMessageForm } from "./CommitMessageView";
-
-type ListPagination = {
-  pageSize: number;
-  hasMore: boolean;
-  onLoadMore: () => void;
-};
 
 interface CommitsViewProps {
   gitManager: GitManager;
@@ -109,6 +103,7 @@ export function CommitsView({
       pagination={pagination}
       navigationTitle="Repository Commits"
       searchBarPlaceholder="Search commits by message, sha, author, tags, files..."
+      selectedItemId={selectedCommitId || undefined}
       onSelectionChange={(id) => setSelectedCommitId(id)}
       isShowingDetail={isShowingDetail}
       searchBarAccessory={viewDropdown}
@@ -206,6 +201,11 @@ export function CommitsView({
               branchFilter={branchFilter}
               updateSelectedBranch={setBranchFilter}
               branchesState={branchesState}
+              onMoveToCommit={(commitHash) => {
+                setSelectedCommitId(commitHash);
+              }}
+              commits={commits}
+              pagination={pagination}
             />
           ))}
         </List.Section>
@@ -231,6 +231,9 @@ interface CommitListItemProps {
   branchFilter: string;
   updateSelectedBranch: (branchName: string) => void;
   branchesState?: BranchesState;
+  onMoveToCommit: (commitHash: string) => void;
+  commits: Commit[];
+  pagination?: ListPagination;
 }
 
 function CommitListItem({
@@ -250,6 +253,9 @@ function CommitListItem({
   branchFilter,
   updateSelectedBranch,
   branchesState,
+  onMoveToCommit,
+  commits,
+  pagination,
 }: CommitListItemProps) {
   const icon = useMemo(() => {
     if (selectedBranch && 'type' in selectedBranch && selectedBranch.ahead) {
@@ -469,10 +475,13 @@ function CommitListItem({
               icon={Icon.Document}
               target={
                 <CommitDiffView
-                  commit={commit}
+                  index={index}
+                  commits={commits}
                   gitManager={gitManager}
                   navigationActions={navigationActions}
                   onRefresh={onRefresh}
+                  pagination={pagination}
+                  onMoveToCommit={onMoveToCommit}
                 />
               }
             />

--- a/src/commands/views/CommitsView.tsx
+++ b/src/commands/views/CommitsView.tsx
@@ -104,7 +104,7 @@ export function CommitsView({
       navigationTitle="Repository Commits"
       searchBarPlaceholder="Search commits by message, sha, author, tags, files..."
       selectedItemId={selectedCommitId || undefined}
-      onSelectionChange={(id) => setSelectedCommitId(id)}
+      onSelectionChange={setSelectedCommitId}
       isShowingDetail={isShowingDetail}
       searchBarAccessory={viewDropdown}
       actions={
@@ -201,9 +201,7 @@ export function CommitsView({
               branchFilter={branchFilter}
               updateSelectedBranch={setBranchFilter}
               branchesState={branchesState}
-              onMoveToCommit={(commitHash) => {
-                setSelectedCommitId(commitHash);
-              }}
+              onMoveToCommit={setSelectedCommitId}
               commits={commits}
               pagination={pagination}
             />

--- a/src/commands/views/FileHistoryView.tsx
+++ b/src/commands/views/FileHistoryView.tsx
@@ -195,6 +195,13 @@ function CommitListItem({
                             gitManager={gitManager}
                             onRefresh={onRefresh}
                         />
+                        <FileRestoreAction
+                            filePath={absolutePath}
+                            before={true}
+                            commit={commit.hash}
+                            gitManager={gitManager}
+                            onRefresh={onRefresh}
+                        />
                     </ActionPanel.Section>
 
                     <ActionPanel.Section title="Commit">

--- a/src/commands/views/FileHistoryView.tsx
+++ b/src/commands/views/FileHistoryView.tsx
@@ -37,7 +37,7 @@ export default function FileHistoryView({ gitManager, filePath, onRefresh }: Fil
             isLoading={isLoading}
             navigationTitle={`File History`}
             searchBarPlaceholder="Search commits by message, sha, author..."
-            onSelectionChange={(id) => setSelectedCommitId(id)}
+            onSelectionChange={setSelectedCommitId}
             isShowingDetail={isShowingDetail}
             actions={
                 <ActionPanel>

--- a/src/commands/views/InteractiveRebaseEditorView.tsx
+++ b/src/commands/views/InteractiveRebaseEditorView.tsx
@@ -1,5 +1,5 @@
 import { Action, ActionPanel, Alert, Color, Form, Icon, List, Toast, confirmAlert, showToast, useNavigation } from "@raycast/api";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { GitManager } from "../../utils/git-manager";
 import { Commit, RebaseAction, RebasePlanItem } from "../../types";
 
@@ -121,7 +121,6 @@ export default function InteractiveRebaseEditorView({ gitManager, startFromCommi
                                 title="Rebase"
                                 icon={Icon.Checkmark}
                                 onAction={performRebase}
-                                shortcut={{ modifiers: ["cmd", "shift"], key: "enter" }}
                             />
                             <ActionPanel.Section title="Rebase Action">
                                 <Action

--- a/src/commands/views/StatusView.tsx
+++ b/src/commands/views/StatusView.tsx
@@ -107,17 +107,12 @@ export function StatusView({
           )}
 
           <ActionPanel.Section>
-            <FileRefreshStatusAction onRefresh={revalidateStatus} />
-            <Action
-              title={isShowingDetail ? "Hide Diff" : "Show Diff"}
-              icon={Icon.CodeBlock}
-              onAction={toggleDetail}
-              shortcut={{ modifiers: ["cmd", "shift"], key: "d" }}
-            />
+            <ToggleDetailAction isShowingDetail={isShowingDetail} onToggleDetail={toggleDetail} />
           </ActionPanel.Section>
 
           <ActionPanel.Section title="Workspace">
             <ApplyPatchAction gitManager={gitManager} onRefresh={revalidateStatus} />
+            <FileRefreshStatusAction onRefresh={revalidateStatus} />
           </ActionPanel.Section>
 
           {status && (
@@ -252,6 +247,7 @@ function FileListItem({
             {file.status === "staged" && (
               <>
                 <FileUnstageAction file={file} gitManager={gitManager} onRefresh={onRefresh} />
+                <ToggleDetailAction isShowingDetail={isShowingDetail} onToggleDetail={onToggleDetail} />
                 <FileOpenAction filePath={file.path} />
                 <FileOpenWithAction filePath={file.path} />
                 <FileQuickLookAction filePath={file.path} />
@@ -263,6 +259,7 @@ function FileListItem({
             {(file.status === "unstaged" || file.status === "untracked") && (
               <>
                 <FileStageAction file={file} gitManager={gitManager} onRefresh={onRefresh} />
+                <ToggleDetailAction isShowingDetail={isShowingDetail} onToggleDetail={onToggleDetail} />
                 <FileOpenAction filePath={file.path} />
                 <FileOpenWithAction filePath={file.path} />
                 <FileQuickLookAction filePath={file.path} />
@@ -278,16 +275,6 @@ function FileListItem({
               </>
             )}
             <FileHistoryAction filePath={file.path} gitManager={gitManager} onRefresh={onRefresh} />
-          </ActionPanel.Section>
-
-          <ActionPanel.Section>
-            <FileRefreshStatusAction onRefresh={onRefresh} />
-            <Action
-              title={isShowingDetail ? "Hide Changes" : "Show Changes"}
-              icon={Icon.AppWindowSidebarLeft}
-              onAction={onToggleDetail}
-              shortcut={{ modifiers: ["cmd", "shift"], key: "d" }}
-            />
           </ActionPanel.Section>
 
           <ActionPanel.Section>
@@ -310,11 +297,23 @@ function FileListItem({
             <CreateStashAction gitManager={gitManager} onRefresh={onRefresh} />
             <CreatePatchAction gitManager={gitManager} />
             <ApplyPatchAction gitManager={gitManager} onRefresh={onRefresh} />
+            <FileRefreshStatusAction onRefresh={onRefresh} />
           </ActionPanel.Section>
 
           {navigationActions}
         </ActionPanel>
       }
+    />
+  );
+}
+
+function ToggleDetailAction({ isShowingDetail, onToggleDetail }: { isShowingDetail: boolean, onToggleDetail: () => void }) {
+  return (
+    <Action
+      title={isShowingDetail ? "Hide Changes" : "Show Changes"}
+      icon={Icon.AppWindowSidebarLeft}
+      onAction={onToggleDetail}
+      shortcut={{ modifiers: ["cmd", "shift"], key: "d" }}
     />
   );
 }

--- a/src/components/actions/FileActions.tsx
+++ b/src/components/actions/FileActions.tsx
@@ -316,10 +316,10 @@ export function FileConflictAbortAction({
   }
 }
 
-export function FileRestoreAction({ filePath, commit, gitManager, onRefresh }: { filePath: string, commit: string, gitManager: GitManager, onRefresh: () => void }) {
+export function FileRestoreAction({ filePath, before = false, commit, gitManager, onRefresh }: { filePath: string, before?: boolean, commit: string, gitManager: GitManager, onRefresh: () => void }) {
   const handleRestore = async () => {
     const confirmed = await confirmAlert({
-      title: "Restore File to This Commit",
+      title: before ? "Restore File to Before Commit" : "Restore File to This Commit",
       message: `Are you sure you want to restore '${filePath.split("/").pop()}' to commit ${commit}? This will modify the working tree`,
       primaryAction: {
         title: "Restore",
@@ -329,7 +329,7 @@ export function FileRestoreAction({ filePath, commit, gitManager, onRefresh }: {
 
     if (!confirmed) return;
     try {
-      await gitManager.restoreFileToCommit(filePath, commit);
+      await gitManager.restoreFileToCommit(filePath, before ? `${commit}^` : commit);
       onRefresh();
     } catch (error) {
       // Error toast is shown by GitManager
@@ -338,7 +338,7 @@ export function FileRestoreAction({ filePath, commit, gitManager, onRefresh }: {
 
   return (
     <Action
-      title="Restore File to This Commit"
+      title={before ? "Restore File to Before Commit" : "Restore File to This Commit"}
       icon={Icon.RotateClockwise}
       style={Action.Style.Destructive}
       onAction={handleRestore}

--- a/src/components/actions/RepositoryDirectoryActions.tsx
+++ b/src/components/actions/RepositoryDirectoryActions.tsx
@@ -1,4 +1,6 @@
-import { Action, ActionPanel, Icon, getPreferenceValues } from "@raycast/api";
+import { Action, ActionPanel, Icon, getPreferenceValues, getApplications, open, confirmAlert, Alert, Application } from "@raycast/api";
+import { useEffect, useMemo, useState } from "react";
+import { useCachedState, usePromise } from "@raycast/utils";
 import { Preferences } from "../../types";
 
 interface RepositoryDirectoryActionsProps {
@@ -14,17 +16,62 @@ interface RepositoryDirectoryActionsProps {
  */
 export function RepositoryDirectoryActions({ repositoryPath, onOpen }: RepositoryDirectoryActionsProps) {
   const preferences = getPreferenceValues<Preferences>();
+  const { data: applications } = usePromise(() => getApplications(repositoryPath));
+  const [defaultApp, setDefaultApp] = useCachedState<Application | undefined>(`${repositoryPath}:repo-default-app`, undefined);
+
+  async function handleOpenWith(app: Application) {
+    const remember = await confirmAlert({
+      title: "Remember choise?",
+      message: `Do you want to remember "${app.name}" as the default app for this repository?`,
+      primaryAction: {
+        title: "Remember",
+        style: Alert.ActionStyle.Default,
+      },
+      dismissAction: {
+        title: "No",
+      }
+    });
+
+    await open(repositoryPath, app);
+    onOpen?.();
+
+    if (remember) {
+      setDefaultApp(app);
+    }
+  }
+
+  function handleChangeDefault(app: Application) {
+    setDefaultApp(app);
+  }
 
   return (
     <ActionPanel.Section title={repositoryPath.split("/").pop() || repositoryPath}>
-      <Action.Open
-        title={`Open Repository in ${preferences.defaultEditor.name}`}
-        target={repositoryPath}
-        application={preferences.defaultEditor}
-        icon={{ fileIcon: preferences.defaultEditor.path }}
-        shortcut={{ modifiers: ["cmd", "shift"], key: "o" }}
-        onOpen={() => onOpen?.()}
-      />
+      {defaultApp ? (
+        <Action.Open
+          key={defaultApp.bundleId || defaultApp.path}
+          title="Open Repository"
+          icon={{ fileIcon: defaultApp.path }}
+          application={defaultApp}
+          target={repositoryPath}
+          onOpen={() => onOpen?.()}
+          shortcut={{ modifiers: ["cmd", "shift"], key: "o" }}
+        />
+      ) : (
+        <ActionPanel.Submenu
+          title="Open Repository"
+          icon={Icon.AppWindow}
+          shortcut={{ modifiers: ["cmd", "shift"], key: "o" }}
+        >
+          {applications?.map((app: Application) => (
+            <Action
+              key={app.bundleId || app.path}
+              title={app.name}
+              icon={{ fileIcon: app.path }}
+              onAction={() => handleOpenWith(app)}
+            />
+          ))}
+        </ActionPanel.Submenu>
+      )}
       <Action.Open
         title={`Open Repository in ${preferences.defaultTerminal.name}`}
         target={repositoryPath}
@@ -49,6 +96,21 @@ export function RepositoryDirectoryActions({ repositoryPath, onOpen }: Repositor
         onOpen={() => onOpen?.()}
         shortcut={{ modifiers: ["cmd", "shift", "opt"], key: "o" }}
       />
+      {defaultApp && (
+        <ActionPanel.Submenu
+          title="Change Repository Default App"
+          icon={Icon.AppWindow}
+        >
+          {applications?.map((app: Application) => (
+            <Action
+              key={app.bundleId || app.path}
+              title={app.name}
+              icon={{ fileIcon: app.path }}
+              onAction={() => handleChangeDefault(app)}
+            />
+          ))}
+        </ActionPanel.Submenu>
+      )}
       <Action.CopyToClipboard
         title="Copy Repository Path"
         content={repositoryPath}

--- a/src/components/actions/RepositoryDirectoryActions.tsx
+++ b/src/components/actions/RepositoryDirectoryActions.tsx
@@ -64,7 +64,7 @@ export function RepositoryDirectoryActions({ repositoryPath, onOpen }: Repositor
         >
           {applications?.map((app: Application) => (
             <Action
-              key={app.bundleId || app.path}
+              key={app.path}
               title={app.name}
               icon={{ fileIcon: app.path }}
               onAction={() => handleOpenWith(app)}
@@ -103,7 +103,7 @@ export function RepositoryDirectoryActions({ repositoryPath, onOpen }: Repositor
         >
           {applications?.map((app: Application) => (
             <Action
-              key={app.bundleId || app.path}
+              key={app.path}
               title={app.name}
               icon={{ fileIcon: app.path }}
               onAction={() => handleChangeDefault(app)}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,3 +38,9 @@ export interface UrlTrackerConfig {
   /** URL template where @key will be replaced with the regex match. */
   urlPlaceholder: string;
 }
+
+export type ListPagination = {
+  pageSize: number;
+  hasMore: boolean;
+  onLoadMore: () => void;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,8 +9,6 @@ export type GitView = "branches" | "status" | "commits" | "files" | "stashes";
  * User preferences for the Git Client extension.
  */
 export interface Preferences {
-  /** Default editor for opening files. */
-  defaultEditor: Application;
   /** Default terminal for opening repository directory. */
   defaultTerminal: Application;
   /** External git client for git commands. */

--- a/src/utils/git-manager.ts
+++ b/src/utils/git-manager.ts
@@ -589,6 +589,7 @@ export class GitManager {
       `--max-count=${commitsPerPage}`,
       `--skip=${page * commitsPerPage}`,
       "--name-status",
+      "--first-parent",
       ...(branch ? [branch] : ["--all"]),
       '--decorate=full',
     ]);

--- a/src/utils/git-manager.ts
+++ b/src/utils/git-manager.ts
@@ -550,34 +550,30 @@ export class GitManager {
    * Gets the last commit from the repository.
    */
   async getLastCommit(): Promise<Commit | null> {
-    try {
-      const log = await this.git.log(["--max-count=1", "--name-status", "--decorate=full"]);
+    const log = await this.git.log(["--max-count=1", "--name-status", "--decorate=full"]);
 
-      if (!log.latest) {
-        return null;
-      }
-
-      const commit = log.latest;
-      const changedFiles = this.parseCommitChangedFiles(commit.diff!);
-      const parsedRefs = this.parseCommitRefs(commit.refs);
-
-      return {
-        hash: commit.hash,
-        shortHash: commit.hash.substring(0, 7),
-        message: commit.message,
-        body: commit.body,
-        author: commit.author_name,
-        authorEmail: commit.author_email,
-        date: new Date(commit.date),
-        localBranches: parsedRefs.localBranches,
-        remoteBranches: parsedRefs.remoteBranches,
-        tags: parsedRefs.tags,
-        currentBranchName: parsedRefs.currentBranchName,
-        changedFiles,
-      };
-    } catch (error) {
+    if (!log.latest) {
       return null;
     }
+
+    const commit = log.latest;
+    const changedFiles = this.parseCommitChangedFiles(commit.diff!);
+    const parsedRefs = this.parseCommitRefs(commit.refs);
+
+    return {
+      hash: commit.hash,
+      shortHash: commit.hash.substring(0, 7),
+      message: commit.message,
+      body: commit.body,
+      author: commit.author_name,
+      authorEmail: commit.author_email,
+      date: new Date(commit.date),
+      localBranches: parsedRefs.localBranches,
+      remoteBranches: parsedRefs.remoteBranches,
+      tags: parsedRefs.tags,
+      currentBranchName: parsedRefs.currentBranchName,
+      changedFiles,
+    };
   }
 
   /**


### PR DESCRIPTION
Add an application picker submenu to open repositories, allowing users to choose, remember, and change a default app per repository.

---
<a href="https://cursor.com/background-agent?bcId=bc-81063081-e720-4b44-982e-30112a80f13d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-81063081-e720-4b44-982e-30112a80f13d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

