### PR TITLE
Implement tags view for open repository

### DIFF
--- a/.cursor/rules/repository-tab.mdc
+++ b/.cursor/rules/repository-tab.mdc
@@ -1,0 +1,115 @@
+---
+alwaysApply: false
+---
+Creating a new View in `open-repository.tsx`
+
+Goal: To quickly and consistently add a new View to the Raycast Git Client, preserving the existing architecture, UX, and keeping the context minimal.
+
+1) View File Structure
+- Location: `src/commands/views/<Name>View.tsx`
+- A View is a single React component with the full UI (List/Detail/ActionPanel).
+- Data is passed via `RepositoryContext & NavigationContext` from `open-repository.tsx`.
+- Local subcomponents (e.g., `List.Item`) are only allowed as details of the current View.
+- Reusable `Action`/`ActionPanel.Section` should be taken from `src/components/actions/*`.
+
+Basic Skeleton:
+```tsx
+// src/commands/views/TagsView.tsx
+import { List, ActionPanel, Action, Icon } from "@raycast/api";
+import { NavigationContext, RepositoryContext } from "../../open-repository";
+import { WorkspaceNavigationActions, WorkspaceNavigationDropdown } from "../../components/actions/WorkspaceNavigationActions";
+
+export default function TagsView(context: RepositoryContext & NavigationContext) {
+  return (
+    <List
+      isLoading={context.tags?.isLoading}
+      navigationTitle="Repository Tags"
+      searchBarPlaceholder="Search tags by name..."
+      searchBarAccessory={WorkspaceNavigationDropdown(context)}
+      actions={
+        <ActionPanel>
+          <Action
+            title="Refresh"
+            icon={Icon.ArrowClockwise}
+            onAction={context.tags?.revalidate}
+            shortcut={{ modifiers: ["cmd"], key: "r" }}
+          />
+          <WorkspaceNavigationActions {...context} />
+        </ActionPanel>
+      }
+    >
+      {context.tags?.error ? (
+        <List.EmptyView title="Error loading tags" description={context.tags.error.message} icon={Icon.ExclamationMark} />
+      ) : (context.tags?.data?.length ?? 0) === 0 ? (
+        <List.EmptyView title="No tags" description="No tags found in the repository." icon={Icon.Tag} />
+      ) : (
+        context.tags!.data.map((tag) => (
+          <List.Item
+            key={tag.name}
+            title={tag.name}
+            subtitle={tag.commitHash}
+            actions={
+              <ActionPanel>
+                {/* TagActions here (create/delete/copy/open) */}
+                <WorkspaceNavigationActions {...context} />
+              </ActionPanel>
+            }
+          />
+        ))
+      )}
+    </List>
+  );
+}
+```
+
+2) Entity Naming Conventions
+- Views: `PascalCase` + `View` suffix (e.g., `TagsView.tsx`).
+- Actions: `PascalCase` + `Action(s)` suffix (e.g., `TagActions.tsx`).
+- Hooks: `use` prefix + `camelCase` (e.g., `useGitTags.ts`).
+- Types: `PascalCase` (e.g., `Tag`, `TagsState`).
+- Constants: `UPPER_SNAKE_CASE`.
+- In `src/types/index.ts`, add a new value to the `GitView` type (e.g., `"tags"`).
+
+3) Responsibilities and Relationships
+- View: Handles rendering and `ActionPanel` composition; calls `revalidate`/navigation from the context; business logic resides in `gitManager`.
+- Actions (`src/components/actions/...`): Encapsulate operations (create/delete/rename/push/pull…); use `gitManager` and call `revalidate` on the relevant parts of the context (`status`, `branches`, `remotes`, `commits`, `tags`, …).
+- Hooks (`src/hooks/...`): Load and cache data using `useCachedPromise`; accept `GitManager`, depend on `gitManager.repoPath`, and return `{ data, isLoading, error, revalidate }`.
+- Types (`src/types/...`): Define entities and their states, plus update the `GitView` union type.
+
+4) Connecting a new View in `open-repository.tsx`
+- In `src/types/index.ts`: add the new value to `GitView` (e.g., `"tags"`).
+- Import the View: `import TagsView from "./commands/views/TagsView";`.
+- Instantiate the hook at the top level alongside existing ones (see `useGitBranches`, `useGitStatus`, `useGitRemotes`): `const tagsContext = useGitTags(gitManager);`.
+- Include it in `rootContext` (e.g., `tags: tagsContext`).
+- In the `switch (currentView)` block: add a case for `"tags"` that returns `<TagsView {...rootContext} />`.
+
+5) General Requirements for all Views (aligned with project style)
+- Errors/Toasts: Use direct calls to `showToast()` from `@raycast/api` within Actions; the View should display a `List.EmptyView` on error and allow for a `Refresh`.
+- Destructive Actions: Confirm via `confirmAlert()` with `Alert.ActionStyle.Destructive`.
+- Icons: Use built-in `Icon`s or project SVGs (from `assets/`), not emojis.
+- Shortcuts: Do not assign a shortcut to the first Action; do not use `cmd+enter`, `cmd+k`, or `cmd+p`.
+- Performance: Use `useCachedPromise` with a dependency on `[gitManager.repoPath]`; lazy-load heavy details (see `StatusView` with on-focus diff loading); limit the amount of data in large lists.
+- Navigation: Add `WorkspaceNavigationDropdown(context)` to `searchBarAccessory` and `WorkspaceNavigationActions` to the `ActionPanel`.
+- Empty Lists: Duplicate basic actions in `List.actions` and `List.Item.actions`, as the top-level `List.actions` is only visible when the list is empty.
+
+6) Mini-Template for a New Resource (Abstract Example: Tags)
+- Types: `src/types/git-types.ts`
+```ts
+export interface Tag { name: string; commitHash: string; createdAt?: string }
+export type TagsState = Tag[];
+```
+- Hook: `src/hooks/useGitTags.ts`
+```ts
+import { useCachedPromise } from "@raycast/utils";
+import { GitManager } from "../utils/git-manager";
+import { RepositoryContext } from "../open-repository";
+
+export function useGitTags(gitManager: GitManager): RepositoryContext["tags"] {
+  return useCachedPromise(async () => await gitManager.getTags(), [gitManager.repoPath], { initialData: [] }) as any;
+}
+```
+- Actions: `src/components/actions/TagActions.tsx` — create/delete tag, copy name, open page on provider; use `confirmAlert()` and `showToast()`.
+- View: `src/commands/views/TagsView.tsx` — list of tags, `EmptyView`, sections, actions, `WorkspaceNavigation*`.
+- Connection: Update `GitView`, instantiate `useGitTags`, add it to `rootContext`, and extend the `switch` to render `TagsView`.
+
+In short: Keep UI in the View, operations in Actions, loading/caching in Hooks, types in `src/types`, and routing/aggregation in `open-repository.tsx`. Refer to `StatusView`, `BranchesView`, and `RemotesView` as a reference for style, behavior, and action grouping.

--- a/package.json
+++ b/package.json
@@ -88,6 +88,14 @@
       "description": "Maximum number of branches to load in local and remote branches sections"
     },
     {
+      "name": "maxTagsToLoad",
+      "required": false,
+      "type": "textfield",
+      "title": "Max Tags to Load",
+      "default": "80",
+      "description": "Maximum number of tags to load in tags list"
+    },
+    {
       "name": "autoGenerateCommitMessage",
       "required": false,
       "type": "checkbox",

--- a/src/commands/views/BranchesView.tsx
+++ b/src/commands/views/BranchesView.tsx
@@ -34,12 +34,7 @@ export function BranchesView(context: RepositoryContext & NavigationContext) {
           actions={
             <ActionPanel>
               <ActionPanel.Section title="Branches">
-                <Action
-                  title="Refresh"
-                  icon={Icon.ArrowClockwise}
-                  onAction={context.branches.revalidate}
-                  shortcut={{ modifiers: ["cmd"], key: "r" }}
-                />
+                <RefreshBranchesAction {...context} />
                 <BranchCreateAction {...context} />
                 <RemoteFetchAction {...context} />
               </ActionPanel.Section>
@@ -48,7 +43,7 @@ export function BranchesView(context: RepositoryContext & NavigationContext) {
           }
         />
       ) : !context.branches.data ||
-        (!context.branches.data.currentBranch && !context.branches.data.detachedHead) ? (
+        (!context.branches.isLoading && !context.branches.data.currentBranch && !context.branches.data.detachedHead) ? (
         <List.EmptyView
           title="No branches"
           description="No branches found in the repository."
@@ -58,12 +53,7 @@ export function BranchesView(context: RepositoryContext & NavigationContext) {
               <ActionPanel.Section title="Branches">
                 <BranchCreateAction {...context} />
                 <RemoteFetchAction {...context} />
-                <Action
-                  title="Refresh"
-                  icon={Icon.ArrowClockwise}
-                  onAction={context.branches.revalidate}
-                  shortcut={{ modifiers: ["cmd"], key: "r" }}
-                />
+                <RefreshBranchesAction {...context} />
               </ActionPanel.Section>
               <WorkspaceNavigationActions {...context} />
             </ActionPanel>
@@ -243,12 +233,7 @@ function BranchListItem(context: RepositoryContext & NavigationContext & { branc
           <ActionPanel.Section title="Branches">
             <BranchCreateAction {...context} />
             <RemoteFetchAction {...context} />
-            <Action
-              title="Refresh"
-              icon={Icon.ArrowClockwise}
-              onAction={context.branches.revalidate}
-              shortcut={{ modifiers: ["cmd"], key: "r" }}
-            />
+            <RefreshBranchesAction {...context} />
           </ActionPanel.Section>
           <WorkspaceNavigationActions {...context} />
         </ActionPanel>
@@ -295,16 +280,22 @@ function DetachedHeadListItem(context: RepositoryContext & NavigationContext & {
           <ActionPanel.Section title="Branches">
             <BranchCreateAction {...context} />
             <RemoteFetchAction {...context} />
-            <Action
-              title="Refresh"
-              icon={Icon.ArrowClockwise}
-              onAction={context.branches.revalidate}
-              shortcut={{ modifiers: ["cmd"], key: "r" }}
-            />
+            <RefreshBranchesAction {...context} />
           </ActionPanel.Section>
           <WorkspaceNavigationActions {...context} />
         </ActionPanel>
       }
+    />
+  );
+}
+
+function RefreshBranchesAction(context: RepositoryContext & NavigationContext) {
+  return (
+    <Action
+      title="Refresh"
+      icon={Icon.ArrowClockwise}
+      onAction={context.branches.revalidate}
+      shortcut={{ modifiers: ["cmd"], key: "r" }}
     />
   );
 }

--- a/src/commands/views/FilesView.tsx
+++ b/src/commands/views/FilesView.tsx
@@ -63,6 +63,7 @@ export default function FilesView(context: RepositoryContext & NavigationContext
                 <ActionPanel>
                     <SharedActionsSection
                         onClearRecent={handleClearRecent}
+                        files={recentFiles}
                         {...context}
                     />
                 </ActionPanel>
@@ -76,6 +77,7 @@ export default function FilesView(context: RepositoryContext & NavigationContext
                     actions={<ActionPanel>
                         <SharedActionsSection
                             onClearRecent={handleClearRecent}
+                            files={recentFiles}
                             {...context}
                         />
                     </ActionPanel>}
@@ -105,6 +107,7 @@ export default function FilesView(context: RepositoryContext & NavigationContext
                                 actions={<ActionPanel>
                                     <SharedActionsSection
                                         onClearRecent={handleClearRecent}
+                                        files={recentFiles}
                                         {...context}
                                     />
                                 </ActionPanel>}
@@ -118,6 +121,7 @@ export default function FilesView(context: RepositoryContext & NavigationContext
                             actions={<ActionPanel>
                                 <SharedActionsSection
                                     onClearRecent={handleClearRecent}
+                                    files={recentFiles}
                                     {...context}
                                 />
                             </ActionPanel>}
@@ -175,18 +179,21 @@ function FileListItem(context: RepositoryContext & NavigationContext & {
 }
 
 function SharedActionsSection(context: RepositoryContext & NavigationContext & {
+    files?: string[];
     onClearRecent: () => void
 }) {
     return (
         <>
             <ActionPanel.Section title="Recent">
-                <Action
-                    title="Clear Recent Files"
-                    icon={Icon.Trash}
-                    style={Action.Style.Destructive}
-                    shortcut={{ modifiers: ["cmd", "ctrl"], key: "x" }}
-                    onAction={context.onClearRecent}
-                />
+                {context.files && context.files.length > 0 && (
+                    <Action
+                        title="Clear Recent Files"
+                        icon={Icon.Trash}
+                        style={Action.Style.Destructive}
+                        shortcut={{ modifiers: ["cmd", "ctrl"], key: "x" }}
+                        onAction={context.onClearRecent}
+                    />
+                )}
             </ActionPanel.Section>
             <WorkspaceNavigationActions {...context} />
         </>

--- a/src/commands/views/RemotesView.tsx
+++ b/src/commands/views/RemotesView.tsx
@@ -13,25 +13,25 @@ type RemoteConnectivity = {
 };
 
 export default function RemotesView(context: RepositoryContext & NavigationContext) {
+  const items: Remote[] = useMemo(() => Object.values(context.remotes.data), [context.remotes.data]);
+
   const { data: connectivity, isLoading: isChecking, revalidate: revalidateConnectivity } = usePromise(
-    async (repoPath: string, remoteHosts: string[]) => {
+    async (repoPath: string, remoteHosts: Remote[]) => {
       const entries = await Promise.all(
-        remoteHosts.map(async (name) => {
+        remoteHosts.map(async (remote) => {
           try {
-            await context.gitManager.checkRemoteConnectivity(name);
-            return [name, { reachable: true }] as const;
+            await context.gitManager.checkRemoteConnectivity(remote.name);
+            return [remote.name, { reachable: true }] as const;
           } catch (error) {
-            return [name, { reachable: false, reason: error instanceof Error ? error.message : "Unknown error" }] as const;
+            return [remote.name, { reachable: false, reason: error instanceof Error ? error.message : "Unknown error" }] as const;
           }
         })
       );
 
       return Object.fromEntries(entries) as Record<string, RemoteConnectivity>;
     },
-    [context.gitManager.repoPath, Object.keys(context.remotes.data).map(name => name)]
+    [context.gitManager.repoPath, items]
   );
-
-  const items: Remote[] = useMemo(() => Object.values(context.remotes.data), [context.remotes.data]);
 
   return (
     <List
@@ -47,7 +47,7 @@ export default function RemotesView(context: RepositoryContext & NavigationConte
         </ActionPanel>
       }
     >
-      {items.length === 0 ? (
+      {!isChecking && items.length === 0 ? (
         <List.EmptyView
           title="No remotes"
           description="This repository has no remote configured."

--- a/src/commands/views/StashesView.tsx
+++ b/src/commands/views/StashesView.tsx
@@ -1,6 +1,5 @@
 import { ActionPanel, Action, List, Icon } from "@raycast/api";
-import { StashApplyAction, StashDropAction } from "../../components/actions/StashActions";
-import { GitManager } from "../../utils/git-manager";
+import { StashApplyAction, StashDropAction, StashRenameAction } from "../../components/actions/StashActions";
 import "../../utils/date-utils";
 import { Stash } from "../../types";
 import { getAvatarIcon } from "@raycast/utils";
@@ -16,7 +15,12 @@ export function StashesView(context: RepositoryContext & NavigationContext) {
       searchBarAccessory={WorkspaceNavigationDropdown(context)}
       actions={
         <ActionPanel>
-          <SharedActionsSection {...context} />
+          <Action title="Refresh"
+            onAction={context.stashes.revalidate}
+            icon={Icon.ArrowClockwise}
+            shortcut={{ modifiers: ["cmd"], key: "r" }}
+          />
+          <WorkspaceNavigationActions {...context} />
         </ActionPanel>
       }
     >
@@ -27,7 +31,12 @@ export function StashesView(context: RepositoryContext & NavigationContext) {
           icon={Icon.Bookmark}
           actions={
             <ActionPanel>
-              <SharedActionsSection {...context} />
+              <Action title="Refresh"
+                onAction={context.stashes.revalidate}
+                icon={Icon.ArrowClockwise}
+                shortcut={{ modifiers: ["cmd"], key: "r" }}
+              />
+              <WorkspaceNavigationActions {...context} />
             </ActionPanel>
           }
         />
@@ -53,32 +62,27 @@ function StashListItem(context: RepositoryContext & NavigationContext & {
     <List.Item
       title={context.stash.message}
       icon={{ source: getAvatarIcon(context.stash.author), tooltip: context.stash.author }}
-      subtitle={{ value: context.stash.author, tooltip: context.stash.authorEmail }}
-      accessories={[{ text: context.stash.date.toRelativeDateString(), tooltip: context.stash.date.toRelativeDateString() }]}
+      accessories={[
+        { text: context.stash.author, tooltip: context.stash.authorEmail },
+        { text: context.stash.date.toRelativeDateString(), tooltip: context.stash.date.toRelativeDateString() }
+      ]}
       keywords={[context.stash.hash, context.stash.author, context.stash.authorEmail].filter(Boolean)}
       actions={
         <ActionPanel>
           <ActionPanel.Section>
             <StashApplyAction {...context} />
+            <StashRenameAction {...context} />
             <StashDropAction {...context} />
           </ActionPanel.Section>
 
-          <SharedActionsSection {...context} />
+          <Action title="Refresh"
+            onAction={context.stashes.revalidate}
+            icon={Icon.ArrowClockwise}
+            shortcut={{ modifiers: ["cmd"], key: "r" }}
+          />
+          <WorkspaceNavigationActions {...context} />
         </ActionPanel>
       }
     />
   );
-}
-
-function SharedActionsSection(context: RepositoryContext & NavigationContext) {
-  return (
-    <>
-      <Action title="Refresh Stash"
-        onAction={context.stashes.revalidate}
-        icon={Icon.ArrowClockwise}
-        shortcut={{ modifiers: ["cmd"], key: "r" }}
-      />
-      <WorkspaceNavigationActions {...context} />
-    </>
-  )
 }

--- a/src/commands/views/StashesView.tsx
+++ b/src/commands/views/StashesView.tsx
@@ -15,27 +15,19 @@ export function StashesView(context: RepositoryContext & NavigationContext) {
       searchBarAccessory={WorkspaceNavigationDropdown(context)}
       actions={
         <ActionPanel>
-          <Action title="Refresh"
-            onAction={context.stashes.revalidate}
-            icon={Icon.ArrowClockwise}
-            shortcut={{ modifiers: ["cmd"], key: "r" }}
-          />
+          <RefreshStashesAction {...context} />
           <WorkspaceNavigationActions {...context} />
         </ActionPanel>
       }
     >
-      {!context.stashes.data || context.stashes.data.length === 0 ? (
+      {!context.stashes.isLoading && context.stashes.data.length === 0 ? (
         <List.EmptyView
           title="No stashes"
           description="No saved changes in the stash."
           icon={Icon.Bookmark}
           actions={
             <ActionPanel>
-              <Action title="Refresh"
-                onAction={context.stashes.revalidate}
-                icon={Icon.ArrowClockwise}
-                shortcut={{ modifiers: ["cmd"], key: "r" }}
-              />
+              <RefreshStashesAction {...context} />
               <WorkspaceNavigationActions {...context} />
             </ActionPanel>
           }
@@ -75,14 +67,21 @@ function StashListItem(context: RepositoryContext & NavigationContext & {
             <StashDropAction {...context} />
           </ActionPanel.Section>
 
-          <Action title="Refresh"
-            onAction={context.stashes.revalidate}
-            icon={Icon.ArrowClockwise}
-            shortcut={{ modifiers: ["cmd"], key: "r" }}
-          />
+          <RefreshStashesAction {...context} />
           <WorkspaceNavigationActions {...context} />
         </ActionPanel>
       }
+    />
+  );
+}
+
+function RefreshStashesAction(context: RepositoryContext & NavigationContext) {
+  return (
+    <Action
+      title="Refresh"
+      icon={Icon.ArrowClockwise}
+      onAction={context.stashes.revalidate}
+      shortcut={{ modifiers: ["cmd"], key: "r" }}
     />
   );
 }

--- a/src/commands/views/StatusView.tsx
+++ b/src/commands/views/StatusView.tsx
@@ -235,10 +235,11 @@ function FileListItem(context: NavigationContext & RepositoryContext & {
           </ActionPanel.Section>
 
           <ActionPanel.Section title="Patch">
-            <StashCreateAction {...context} />
             <PatchCreateAction {...context} />
             <PatchApplyAction {...context} />
           </ActionPanel.Section>
+
+          <StashCreateAction {...context} />
 
           <ActionPanel.Section title="Workspace">
             <Action

--- a/src/commands/views/TagsView.tsx
+++ b/src/commands/views/TagsView.tsx
@@ -1,0 +1,109 @@
+import { Action, ActionPanel, Color, Icon, List } from "@raycast/api";
+import { RepositoryContext, NavigationContext } from "../../open-repository";
+import { WorkspaceNavigationActions, WorkspaceNavigationDropdown } from "../../components/actions/WorkspaceNavigationActions";
+import { useGitTags } from "../../hooks/useGitTags";
+import { RemoteFetchAction } from "../../components/actions/RemoteActions";
+import { useMemo } from "react";
+import { TagCheckoutAction, TagCopyNameAction, TagOpenCommitAction, TagPushAction, TagRemoveAction, TagRenameAction } from "../../components/actions/TagActions";
+
+export default function TagsView(context: RepositoryContext & NavigationContext) {
+  const { data, isLoading, error, revalidate } = useGitTags(context.gitManager, context.remotes.data);
+
+  return (
+    <List
+      isLoading={isLoading}
+      navigationTitle="Repository Tags"
+      searchBarPlaceholder="Search tags by name..."
+      searchBarAccessory={WorkspaceNavigationDropdown(context)}
+      actions={
+        <ActionPanel>
+          <Action
+            title="Refresh"
+            icon={Icon.ArrowClockwise}
+            onAction={revalidate}
+            shortcut={{ modifiers: ["cmd"], key: "r" }}
+          />
+          <RemoteFetchAction {...context} />
+          <WorkspaceNavigationActions {...context} />
+        </ActionPanel>
+      }
+    >
+      {error ? (
+        <List.EmptyView
+          title="Error loading tags"
+          description={error.message}
+          icon={Icon.ExclamationMark}
+          actions={
+            <ActionPanel>
+              <Action
+                title="Refresh"
+                icon={Icon.ArrowClockwise}
+                onAction={revalidate}
+                shortcut={{ modifiers: ["cmd"], key: "r" }}
+              />
+              <RemoteFetchAction {...context} />
+              <WorkspaceNavigationActions {...context} />
+            </ActionPanel>
+          }
+        />
+      ) : (
+        <>
+          {/* Local tags */}
+          {(data.local?.length ?? 0) > 0 && (
+            <List.Section title="Local Tags">
+              {data.local.map((tag) => (
+                <TagListItem key={`local:${tag.name}`} tagName={tag.name} commitHash={tag.commitHash} {...context} />
+              ))}
+            </List.Section>
+          )}
+
+          {/* Remote tags grouped by remote */}
+          {Object.entries(data.remotes || {}).map(([remote, tags]) => (
+            <List.Section key={remote} title={`${remote} • ${context.remotes.data[remote]?.organizationName}/${context.remotes.data[remote]?.repositoryName}`}>
+              {tags.map((tag) => (
+                <TagListItem key={`${remote}:${tag.name}`} tagName={tag.name} commitHash={tag.commitHash} remote={remote} {...context} />
+              ))}
+            </List.Section>
+          ))}
+
+          {/* Empty state if nothing */}
+          {(!data.local || data.local.length === 0) && Object.values(data.remotes || {}).every((arr) => (arr?.length ?? 0) === 0) && (
+            <List.EmptyView title="No tags" description="Repository has no tags." icon={Icon.Tag} />
+          )}
+        </>
+      )}
+    </List>
+  );
+}
+
+function TagListItem(context: RepositoryContext & NavigationContext & { tagName: string; commitHash: string; remote?: string }) {
+  const accessories = useMemo(() => {
+    const items: List.Item.Accessory[] = [];
+    items.push({ text: context.commitHash.substring(0, 7), tooltip: context.commitHash });
+    if (context.remote) items.push({ tag: { value: context.remote, color: Color.SecondaryText }, icon: Icon.Network });
+    return items;
+  }, [context.commitHash, context.remote]);
+
+  return (
+    <List.Item
+      title={context.tagName}
+      icon={Icon.Tag}
+      accessories={accessories}
+      keywords={[context.tagName, context.commitHash, context.remote].filter(Boolean) as string[]}
+      actions={
+        <ActionPanel>
+          <ActionPanel.Section title={`Tag '${context.tagName}'`}>
+            <TagOpenCommitAction commitHash={context.commitHash} {...context} />
+            <TagCheckoutAction tagName={context.tagName} {...context} />
+            <TagPushAction tagName={context.tagName} {...context} />
+            <TagRenameAction tagName={context.tagName} {...context} />
+            <TagCopyNameAction tagName={context.tagName} />
+            <TagRemoveAction tagName={context.tagName} {...context} />
+          </ActionPanel.Section>
+          <WorkspaceNavigationActions {...context} />
+        </ActionPanel>
+      }
+    />
+  );
+}
+

--- a/src/commands/views/TagsView.tsx
+++ b/src/commands/views/TagsView.tsx
@@ -1,105 +1,117 @@
-import { Action, ActionPanel, Color, Icon, List } from "@raycast/api";
+import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { RepositoryContext, NavigationContext } from "../../open-repository";
 import { WorkspaceNavigationActions, WorkspaceNavigationDropdown } from "../../components/actions/WorkspaceNavigationActions";
-import { useGitTags } from "../../hooks/useGitTags";
 import { RemoteFetchAction } from "../../components/actions/RemoteActions";
 import { useMemo } from "react";
-import { TagCheckoutAction, TagCopyNameAction, TagOpenCommitAction, TagPushAction, TagRemoveAction, TagRenameAction } from "../../components/actions/TagActions";
+import { TagCheckoutAction, TagCopyCommitHashAction, TagCopyNameAction, TagOpenCommitAction, TagPushAction, TagRemoveAction, TagRenameAction } from "../../components/actions/TagActions";
+import { Tag } from "../../types";
 
 export default function TagsView(context: RepositoryContext & NavigationContext) {
-  const { data, isLoading, error, revalidate } = useGitTags(context.gitManager, context.remotes.data);
-
   return (
     <List
-      isLoading={isLoading}
+      isLoading={context.tags.isLoading}
       navigationTitle="Repository Tags"
       searchBarPlaceholder="Search tags by name..."
       searchBarAccessory={WorkspaceNavigationDropdown(context)}
       actions={
         <ActionPanel>
-          <Action
-            title="Refresh"
-            icon={Icon.ArrowClockwise}
-            onAction={revalidate}
-            shortcut={{ modifiers: ["cmd"], key: "r" }}
-          />
+          <RefreshTagsAction {...context} />
           <RemoteFetchAction {...context} />
           <WorkspaceNavigationActions {...context} />
         </ActionPanel>
       }
     >
-      {error ? (
+      {context.tags.error ? (
         <List.EmptyView
           title="Error loading tags"
-          description={error.message}
+          description={context.tags.error.message}
           icon={Icon.ExclamationMark}
           actions={
             <ActionPanel>
-              <Action
-                title="Refresh"
-                icon={Icon.ArrowClockwise}
-                onAction={revalidate}
-                shortcut={{ modifiers: ["cmd"], key: "r" }}
-              />
+              <RefreshTagsAction {...context} />
+              <RemoteFetchAction {...context} />
+              <WorkspaceNavigationActions {...context} />
+            </ActionPanel>
+          }
+        />
+      ) : !context.tags.isLoading && context.tags.data.length === 0 ? (
+        <List.EmptyView
+          title="No tags"
+          description="Repository has no tags."
+          icon={Icon.Tag}
+          actions={
+            <ActionPanel>
+              <RefreshTagsAction {...context} />
               <RemoteFetchAction {...context} />
               <WorkspaceNavigationActions {...context} />
             </ActionPanel>
           }
         />
       ) : (
-        <>
-          {/* Local tags */}
-          {(data.local?.length ?? 0) > 0 && (
-            <List.Section title="Local Tags">
-              {data.local.map((tag) => (
-                <TagListItem key={`local:${tag.name}`} tagName={tag.name} commitHash={tag.commitHash} {...context} />
-              ))}
-            </List.Section>
-          )}
-
-          {/* Remote tags grouped by remote */}
-          {Object.entries(data.remotes || {}).map(([remote, tags]) => (
-            <List.Section key={remote} title={`${remote} • ${context.remotes.data[remote]?.organizationName}/${context.remotes.data[remote]?.repositoryName}`}>
-              {tags.map((tag) => (
-                <TagListItem key={`${remote}:${tag.name}`} tagName={tag.name} commitHash={tag.commitHash} remote={remote} {...context} />
-              ))}
-            </List.Section>
-          ))}
-
-          {/* Empty state if nothing */}
-          {(!data.local || data.local.length === 0) && Object.values(data.remotes || {}).every((arr) => (arr?.length ?? 0) === 0) && (
-            <List.EmptyView title="No tags" description="Repository has no tags." icon={Icon.Tag} />
-          )}
-        </>
+        context.tags.data.map((tag) => (
+          <TagListItem
+            key={`local:${tag.name}`}
+            tag={tag}
+            {...context}
+          />
+        ))
       )}
     </List>
   );
 }
 
-function TagListItem(context: RepositoryContext & NavigationContext & { tagName: string; commitHash: string; remote?: string }) {
+function TagListItem(context: RepositoryContext & NavigationContext & { tag: Tag }) {
   const accessories = useMemo(() => {
     const items: List.Item.Accessory[] = [];
-    items.push({ text: context.commitHash.substring(0, 7), tooltip: context.commitHash });
-    if (context.remote) items.push({ tag: { value: context.remote, color: Color.SecondaryText }, icon: Icon.Network });
+
+    if (context.tag.author) {
+      items.push({ text: context.tag.author, tooltip: context.tag.authorEmail });
+    }
+
+    if (context.tag.date) {
+      items.push({
+        text: context.tag.date.toRelativeDateString(),
+        tooltip: Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(context.tag.date)
+      });
+    }
+
     return items;
-  }, [context.commitHash, context.remote]);
+  }, [context.tag.author, context.tag.date]);
 
   return (
     <List.Item
-      title={context.tagName}
+      title={context.tag.name}
+      subtitle={{
+        value: context.tag.message,
+        tooltip: context.tag.message
+      }}
       icon={Icon.Tag}
       accessories={accessories}
-      keywords={[context.tagName, context.commitHash, context.remote].filter(Boolean) as string[]}
+      keywords={[
+        context.tag.name,
+        context.tag.commitHash,
+        context.tag.message,
+        context.tag.author,
+        context.tag.authorEmail
+      ].filter(Boolean) as string[]}
       actions={
         <ActionPanel>
-          <ActionPanel.Section title={`Tag '${context.tagName}'`}>
-            <TagOpenCommitAction commitHash={context.commitHash} {...context} />
-            <TagCheckoutAction tagName={context.tagName} {...context} />
-            <TagPushAction tagName={context.tagName} {...context} />
-            <TagRenameAction tagName={context.tagName} {...context} />
-            <TagCopyNameAction tagName={context.tagName} />
-            <TagRemoveAction tagName={context.tagName} {...context} />
+          <ActionPanel.Section title={`Tag '${context.tag.name}'`}>
+            <TagOpenCommitAction commitHash={context.tag.commitHash} {...context} />
+            <TagCheckoutAction tagName={context.tag.name} {...context} />
+            <TagPushAction tagName={context.tag.name} {...context} />
+            <TagRenameAction tagName={context.tag.name} {...context} />
+            <TagCopyNameAction
+              tagName={context.tag.name}
+              shortcut={{ modifiers: ["cmd"], key: "c" }}
+            />
+            <TagCopyCommitHashAction
+              commitHash={context.tag.commitHash}
+              shortcut={{ modifiers: ["cmd", "opt"], key: "c" }}
+            />
+            <TagRemoveAction tagName={context.tag.name} {...context} />
           </ActionPanel.Section>
+          <RefreshTagsAction {...context} />
           <WorkspaceNavigationActions {...context} />
         </ActionPanel>
       }
@@ -107,3 +119,13 @@ function TagListItem(context: RepositoryContext & NavigationContext & { tagName:
   );
 }
 
+function RefreshTagsAction(context: RepositoryContext & NavigationContext) {
+  return (
+    <Action
+      title="Refresh"
+      icon={Icon.ArrowClockwise}
+      onAction={context.tags.revalidate}
+      shortcut={{ modifiers: ["cmd"], key: "r" }}
+    />
+  );
+}

--- a/src/components/actions/BranchActions.tsx
+++ b/src/components/actions/BranchActions.tsx
@@ -58,7 +58,7 @@ export function BranchCkeckoutAction(context: RepositoryContext & NavigationCont
 export function BranchDeleteAction(context: RepositoryContext & { branch: Branch }) {
   const handleDeleteBranch = async () => {
     const confirmed = await confirmAlert({
-      title: "Delete",
+      title: "Delete branch?",
       message: `Are you sure you want to delete branch "${context.branch.name}"?`,
       primaryAction: {
         title: "Delete",

--- a/src/components/actions/StashActions.tsx
+++ b/src/components/actions/StashActions.tsx
@@ -132,3 +132,56 @@ function StashCreateForm(context: RepositoryContext & { scope: PatchScope }) {
     </Form>
   );
 }
+
+/**
+ * Action for renaming a stash.
+ */
+export function StashRenameAction(context: RepositoryContext & NavigationContext & { stash: Stash, index: number }) {
+  return (
+    <Action.Push
+      title="Rename Stash"
+      icon={Icon.Pencil}
+      shortcut={{ modifiers: ["cmd"], key: "e" }}
+      target={<StashRenameForm {...context} />}
+    />
+  );
+}
+
+function StashRenameForm(context: RepositoryContext & NavigationContext & { stash: Stash; index: number }) {
+  const { pop } = useNavigation();
+  const [newName, setNewName] = useState(context.stash.message);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (values: { newName: string }) => {
+    setIsLoading(true);
+    try {
+      await context.gitManager.renameStash(context.index, context.stash, values.newName);
+      context.stashes.revalidate();
+      pop();
+    } catch (error) {
+      // Git error is already shown by GitManager
+    }
+    setIsLoading(false);
+  };
+
+  return (
+    <Form
+      navigationTitle="Rename Stash"
+      isLoading={isLoading}
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Rename Stash" onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.TextField
+        id="newName"
+        title="Stash Name"
+        placeholder="New stash name"
+        error={newName.trim().length === 0 ? "Required" : undefined}
+        value={newName}
+        onChange={setNewName}
+      />
+    </Form>
+  );
+}

--- a/src/components/actions/StashActions.tsx
+++ b/src/components/actions/StashActions.tsx
@@ -1,6 +1,6 @@
 import { ActionPanel, Action, Icon, confirmAlert, Alert, Form, useNavigation } from "@raycast/api";
 import { useState } from "react";
-import { Stash } from "../../types";
+import { PatchScope, Stash } from "../../types";
 import { NavigationContext, RepositoryContext } from "../../open-repository";
 
 /**
@@ -76,22 +76,34 @@ export function StashDropAction(context: RepositoryContext & NavigationContext &
 
 export function StashCreateAction(context: RepositoryContext) {
   return (
-    <Action.Push
-      title={"Stash Changes"}
+    <ActionPanel.Submenu
+      title="Create Stash"
       icon={Icon.Bookmark}
-      target={<StashCreateForm {...context} />}
       shortcut={{ modifiers: ["cmd"], key: "s" }}
-    />
+    >
+      <Action.Push
+        title="All Changes"
+        target={<StashCreateForm scope={PatchScope.ALL} {...context} />}
+      />
+      <Action.Push
+        title="Only Staged"
+        target={<StashCreateForm scope={PatchScope.STAGED} {...context} />}
+      />
+      <Action.Push
+        title="Only Unstaged"
+        target={<StashCreateForm scope={PatchScope.UNSTAGED} {...context} />}
+      />
+    </ActionPanel.Submenu>
   );
 }
 
-function StashCreateForm(context: RepositoryContext) {
+function StashCreateForm(context: RepositoryContext & { scope: PatchScope }) {
   const { pop } = useNavigation();
   const [message, setMessage] = useState("");
 
   const handleSubmit = async (values: { message: string }) => {
     try {
-      await context.gitManager.stash(values.message);
+      await context.gitManager.stash(values.message, context.scope);
       context.stashes.revalidate();
       pop();
     } catch (error) {
@@ -99,13 +111,12 @@ function StashCreateForm(context: RepositoryContext) {
     }
   };
 
-
   return (
     <Form
-      navigationTitle={"Stash Changes"}
+      navigationTitle={"Create Stash"}
       actions={
         <ActionPanel>
-          <Action.SubmitForm title={"Stash Changes"} onSubmit={handleSubmit} />
+          <Action.SubmitForm title={"Create Stash"} onSubmit={handleSubmit} />
         </ActionPanel>
       }
     >

--- a/src/components/actions/TagActions.tsx
+++ b/src/components/actions/TagActions.tsx
@@ -1,4 +1,4 @@
-import { Action, Icon, confirmAlert, Alert, ActionPanel, useNavigation, showToast, Toast, Form } from "@raycast/api";
+import { Action, Icon, confirmAlert, Alert, ActionPanel, useNavigation, showToast, Toast, Form, List, Keyboard } from "@raycast/api";
 import { Commit } from "../../types";
 import { RemoteHostIcon } from "../icons/RemoteHostIcons";
 import { NavigationContext, RepositoryContext } from "../../open-repository";
@@ -26,10 +26,10 @@ export function TagCreateAction(context: RepositoryContext & { commit: Commit })
 export function TagRemoveAction(context: RepositoryContext & { tagName: string }) {
   const handleRemoveTag = async (remote?: string) => {
     const confirmed = await confirmAlert({
-      title: "Push tag deletion to remote?",
-      message: `Are you sure you want to push tag deletion to remote?`,
+      title: "Delete tag?",
+      message: `Are you sure you want to delete tag "${context.tagName}"?`,
       primaryAction: {
-        title: "Push",
+        title: "Delete",
         style: Alert.ActionStyle.Destructive,
       },
     });
@@ -43,10 +43,10 @@ export function TagRemoveAction(context: RepositoryContext & { tagName: string }
 
       if (Object.keys(context.remotes.data).length === 1) {
         const confirmed = await confirmAlert({
-          title: "Remove tag",
-          message: `Are you sure you want to remove tag "${context.tagName}"?`,
+          title: "Delete remote tag",
+          message: `Are you sure you want to delete remote tag "${context.tagName}"?`,
           primaryAction: {
-            title: "Remove",
+            title: "Delete",
             style: Alert.ActionStyle.Destructive,
           },
         });
@@ -59,9 +59,7 @@ export function TagRemoveAction(context: RepositoryContext & { tagName: string }
 
       await context.gitManager.deleteTag(context.tagName);
       context.commits.revalidate();
-      // Refresh tags list if available in context
-      // @ts-expect-error optional tags context
-      context.tags?.revalidate?.();
+      context.tags.revalidate();
     } catch (error) {
       // Git error is already shown by GitManager
     }
@@ -74,6 +72,7 @@ export function TagRemoveAction(context: RepositoryContext & { tagName: string }
         onAction={() => handleRemoveTag(undefined)}
         icon={Icon.Trash}
         style={Action.Style.Destructive}
+        shortcut={{ modifiers: ["ctrl"], key: "x" }}
       />
     );
   }
@@ -82,6 +81,7 @@ export function TagRemoveAction(context: RepositoryContext & { tagName: string }
     <ActionPanel.Submenu
       title={`Remove Tag '${context.tagName} from'`}
       icon={Icon.Trash}
+      shortcut={{ modifiers: ["ctrl"], key: "x" }}
     >
       <Action
         title={`Local Only`}
@@ -104,10 +104,19 @@ export function TagRemoveAction(context: RepositoryContext & { tagName: string }
 /**
  * Action for copying tag name to clipboard.
  */
-export function TagCopyNameAction({ tagName }: { tagName: string }) {
+export function TagCopyNameAction({ tagName, shortcut }: { tagName: string, shortcut?: Keyboard.Shortcut }) {
   return <Action.CopyToClipboard
     title={`Copy Tag Name '${tagName}'`}
     content={tagName} icon={Icon.Clipboard}
+    shortcut={shortcut}
+  />;
+}
+
+export function TagCopyCommitHashAction({ commitHash, shortcut }: { commitHash: string, shortcut?: Keyboard.Shortcut }) {
+  return <Action.CopyToClipboard
+    title={`Copy Commit Hash '${commitHash}'`}
+    content={commitHash} icon={Icon.Clipboard}
+    shortcut={shortcut}
   />;
 }
 
@@ -119,7 +128,10 @@ export function TagCheckoutAction(context: RepositoryContext & NavigationContext
     const confirmed = await confirmAlert({
       title: "Checkout Tag",
       message: `Are you sure you want to checkout tag "${context.tagName}"? This will put HEAD into detached state.`,
-      primaryAction: { title: "Checkout", style: Alert.ActionStyle.Default },
+      primaryAction: {
+        title: "Checkout",
+        style: Alert.ActionStyle.Default,
+      },
     });
     if (!confirmed) return;
 
@@ -135,7 +147,11 @@ export function TagCheckoutAction(context: RepositoryContext & NavigationContext
   };
 
   return (
-    <Action title="Checkout Tag" icon={Icon.ArrowDown} onAction={handleCheckout} />
+    <Action
+      title="Checkout Tag"
+      onAction={handleCheckout}
+      icon={`arrow-checkout.svg`}
+    />
   );
 }
 
@@ -146,8 +162,7 @@ export function TagPushAction(context: RepositoryContext & { tagName: string }) 
   const handlePush = async (remote: string) => {
     try {
       await context.gitManager.pushTag(context.tagName, remote);
-      // @ts-expect-error optional tags context
-      context.tags?.revalidate?.();
+      context.tags.revalidate();
     } catch (error) {
       // handled by GitManager
     }
@@ -159,12 +174,21 @@ export function TagPushAction(context: RepositoryContext & { tagName: string }) 
 
   if (Object.keys(context.remotes.data).length === 1) {
     return (
-      <Action title="Push Tag" icon={Icon.Upload} onAction={() => handlePush(Object.keys(context.remotes.data)[0])} />
+      <Action
+        title="Push Tag"
+        icon={`git-push.svg`}
+        onAction={() => handlePush(Object.keys(context.remotes.data)[0])}
+        shortcut={{ modifiers: ["cmd", "shift"], key: "p" }}
+      />
     );
   }
 
   return (
-    <ActionPanel.Submenu title="Push Tag to" icon={Icon.Upload}>
+    <ActionPanel.Submenu
+      title="Push Tag to"
+      icon={`git-push.svg`}
+      shortcut={{ modifiers: ["cmd", "shift"], key: "p" }}
+    >
       {Object.keys(context.remotes.data).map((remote) => (
         <Action
           key={`${remote}:push-tag`}
@@ -182,7 +206,12 @@ export function TagPushAction(context: RepositoryContext & { tagName: string }) 
  */
 export function TagRenameAction(context: RepositoryContext & { tagName: string }) {
   return (
-    <Action.Push title="Rename Tag" icon={Icon.Pencil} target={<TagRenameForm {...context} />} />
+    <Action.Push
+      title="Rename Tag"
+      icon={Icon.Pencil}
+      target={<TagRenameForm {...context} />}
+      shortcut={{ modifiers: ["cmd"], key: "e" }}
+    />
   );
 }
 
@@ -194,10 +223,9 @@ function TagRenameForm(context: RepositoryContext & { tagName: string }) {
   const onSubmit = async (values: { newName: string }) => {
     setIsLoading(true);
     try {
-      await context.gitManager.renameTag(context.tagName, values.newName.trim());
+      await context.gitManager.renameTag(context.tagName, values.newName);
       context.commits.revalidate();
-      // @ts-expect-error optional tags context
-      context.tags?.revalidate?.();
+      context.tags.revalidate();
       pop();
     } catch (error) {
       // handled by GitManager
@@ -209,9 +237,20 @@ function TagRenameForm(context: RepositoryContext & { tagName: string }) {
     <Form
       navigationTitle={`Rename Tag '${context.tagName}'`}
       isLoading={isLoading}
-      actions={<ActionPanel><Action.SubmitForm title="Rename" onSubmit={onSubmit} /></ActionPanel>}
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Rename" onSubmit={onSubmit} />
+        </ActionPanel>
+      }
     >
-      <Form.TextField id="newName" title="New Name" value={newName} onChange={setNewName} placeholder="vX.Y.Z" />
+      <Form.TextField
+        id="newName"
+        title="New Name"
+        value={newName}
+        onChange={setNewName}
+        placeholder="x.y.z"
+        error={newName.trim().length === 0 ? "Required" : undefined}
+      />
     </Form>
   );
 }
@@ -220,29 +259,28 @@ function TagRenameForm(context: RepositoryContext & { tagName: string }) {
  * Action to open commit details for the tag's commit
  */
 export function TagOpenCommitAction(context: RepositoryContext & NavigationContext & { commitHash: string }) {
-  const { data: commit, isLoading } = usePromise(async (hash: string) => {
+  const { data: commit } = usePromise(async (hash: string) => {
     return await context.gitManager.getCommitByHash(hash);
   }, [context.commitHash]);
 
+  if (!commit) {
+    return undefined;
+  }
+
   return (
     <Action.Push
-      title="View Commit"
+      title="Show Commit"
       icon={Icon.Document}
       target={
-        commit ? (
-          <CommitDetailsView
-            {...context}
-            index={0}
-            onMoveToCommit={() => {}}
-            commits={{
-              ...context.commits,
-              data: [commit],
-              pagination: undefined,
-            }}
-          />
-        ) : (
-          <List isLoading={isLoading} navigationTitle="Commit Details"><List.EmptyView title="Loading commit..." /></List>
-        )
+        <CommitDetailsView
+          {...context}
+          index={0}
+          onMoveToCommit={() => { }}
+          commits={{
+            ...context.commits,
+            data: [commit]
+          }}
+        />
       }
     />
   );
@@ -283,6 +321,7 @@ function TagCreateForm(context: RepositoryContext & { commit: Commit }) {
 
       // Refresh the commits list
       context.commits.revalidate();
+      context.tags.revalidate();
       pop();
     } catch (error) {
       // Git error is already shown by GitManager
@@ -301,7 +340,10 @@ function TagCreateForm(context: RepositoryContext & { commit: Commit }) {
             onAction={() => handleSubmit(undefined)}
             icon={Icon.Tag}
           />
-          <TagCreateAndPushAction {...context} handleSubmit={(remote) => handleSubmit(remote)} />
+          <TagCreateAndPushAction
+            {...context}
+            handleSubmit={(remote) => handleSubmit(remote)}
+          />
         </ActionPanel>
       }
     >

--- a/src/components/actions/TagActions.tsx
+++ b/src/components/actions/TagActions.tsx
@@ -1,8 +1,10 @@
 import { Action, Icon, confirmAlert, Alert, ActionPanel, useNavigation, showToast, Toast, Form } from "@raycast/api";
 import { Commit } from "../../types";
 import { RemoteHostIcon } from "../icons/RemoteHostIcons";
-import { RepositoryContext } from "../../open-repository";
+import { NavigationContext, RepositoryContext } from "../../open-repository";
 import { useState } from "react";
+import { usePromise } from "@raycast/utils";
+import { CommitDetailsView } from "../../commands/views/CommitDetailsView";
 
 /**
  * Action for creating a tag on a commit.
@@ -57,6 +59,9 @@ export function TagRemoveAction(context: RepositoryContext & { tagName: string }
 
       await context.gitManager.deleteTag(context.tagName);
       context.commits.revalidate();
+      // Refresh tags list if available in context
+      // @ts-expect-error optional tags context
+      context.tags?.revalidate?.();
     } catch (error) {
       // Git error is already shown by GitManager
     }
@@ -104,6 +109,143 @@ export function TagCopyNameAction({ tagName }: { tagName: string }) {
     title={`Copy Tag Name '${tagName}'`}
     content={tagName} icon={Icon.Clipboard}
   />;
+}
+
+/**
+ * Action for checking out a tag (detached HEAD).
+ */
+export function TagCheckoutAction(context: RepositoryContext & NavigationContext & { tagName: string }) {
+  const handleCheckout = async () => {
+    const confirmed = await confirmAlert({
+      title: "Checkout Tag",
+      message: `Are you sure you want to checkout tag "${context.tagName}"? This will put HEAD into detached state.`,
+      primaryAction: { title: "Checkout", style: Alert.ActionStyle.Default },
+    });
+    if (!confirmed) return;
+
+    try {
+      await context.gitManager.checkoutTag(context.tagName);
+      context.status.revalidate();
+      context.branches.revalidate();
+      context.commits.revalidate();
+      context.navigateTo("status");
+    } catch (error) {
+      // handled by GitManager
+    }
+  };
+
+  return (
+    <Action title="Checkout Tag" icon={Icon.ArrowDown} onAction={handleCheckout} />
+  );
+}
+
+/**
+ * Action for pushing a tag to remote.
+ */
+export function TagPushAction(context: RepositoryContext & { tagName: string }) {
+  const handlePush = async (remote: string) => {
+    try {
+      await context.gitManager.pushTag(context.tagName, remote);
+      // @ts-expect-error optional tags context
+      context.tags?.revalidate?.();
+    } catch (error) {
+      // handled by GitManager
+    }
+  };
+
+  if (!context.remotes.data || Object.keys(context.remotes.data).length === 0) {
+    return null;
+  }
+
+  if (Object.keys(context.remotes.data).length === 1) {
+    return (
+      <Action title="Push Tag" icon={Icon.Upload} onAction={() => handlePush(Object.keys(context.remotes.data)[0])} />
+    );
+  }
+
+  return (
+    <ActionPanel.Submenu title="Push Tag to" icon={Icon.Upload}>
+      {Object.keys(context.remotes.data).map((remote) => (
+        <Action
+          key={`${remote}:push-tag`}
+          title={remote}
+          icon={RemoteHostIcon(context.remotes.data[remote].provider)}
+          onAction={() => handlePush(remote)}
+        />
+      ))}
+    </ActionPanel.Submenu>
+  );
+}
+
+/**
+ * Action for renaming a tag.
+ */
+export function TagRenameAction(context: RepositoryContext & { tagName: string }) {
+  return (
+    <Action.Push title="Rename Tag" icon={Icon.Pencil} target={<TagRenameForm {...context} />} />
+  );
+}
+
+function TagRenameForm(context: RepositoryContext & { tagName: string }) {
+  const { pop } = useNavigation();
+  const [newName, setNewName] = useState(context.tagName);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const onSubmit = async (values: { newName: string }) => {
+    setIsLoading(true);
+    try {
+      await context.gitManager.renameTag(context.tagName, values.newName.trim());
+      context.commits.revalidate();
+      // @ts-expect-error optional tags context
+      context.tags?.revalidate?.();
+      pop();
+    } catch (error) {
+      // handled by GitManager
+    }
+    setIsLoading(false);
+  };
+
+  return (
+    <Form
+      navigationTitle={`Rename Tag '${context.tagName}'`}
+      isLoading={isLoading}
+      actions={<ActionPanel><Action.SubmitForm title="Rename" onSubmit={onSubmit} /></ActionPanel>}
+    >
+      <Form.TextField id="newName" title="New Name" value={newName} onChange={setNewName} placeholder="vX.Y.Z" />
+    </Form>
+  );
+}
+
+/**
+ * Action to open commit details for the tag's commit
+ */
+export function TagOpenCommitAction(context: RepositoryContext & NavigationContext & { commitHash: string }) {
+  const { data: commit, isLoading } = usePromise(async (hash: string) => {
+    return await context.gitManager.getCommitByHash(hash);
+  }, [context.commitHash]);
+
+  return (
+    <Action.Push
+      title="View Commit"
+      icon={Icon.Document}
+      target={
+        commit ? (
+          <CommitDetailsView
+            {...context}
+            index={0}
+            onMoveToCommit={() => {}}
+            commits={{
+              ...context.commits,
+              data: [commit],
+              pagination: undefined,
+            }}
+          />
+        ) : (
+          <List isLoading={isLoading} navigationTitle="Commit Details"><List.EmptyView title="Loading commit..." /></List>
+        )
+      }
+    />
+  );
 }
 
 function TagCreateForm(context: RepositoryContext & { commit: Commit }) {

--- a/src/components/actions/WorkspaceNavigationActions.tsx
+++ b/src/components/actions/WorkspaceNavigationActions.tsx
@@ -48,6 +48,12 @@ export function WorkspaceNavigationDropdown(context: NavigationContext) {
                 keywords={["history", "ls-files", "workspace", "project"]}
                 icon={Icon.Clock}
             />
+            <List.Dropdown.Item
+                title="Tags"
+                value="tags"
+                keywords={["release", "refs/tags"]}
+                icon={Icon.Tag}
+            />
         </List.Dropdown>
     );
 }
@@ -91,6 +97,11 @@ export function WorkspaceNavigationActions(context: NavigationContext & Reposito
                     onAction={() => context.navigateTo("files")}
                     icon={Icon.Folder}
                     shortcut={{ modifiers: ["cmd"], key: "0" }}
+                />
+                <Action
+                    title="Go to Tags"
+                    onAction={() => context.navigateTo("tags")}
+                    icon={Icon.Tag}
                 />
             </ActionPanel.Section>
 

--- a/src/components/actions/WorkspaceNavigationActions.tsx
+++ b/src/components/actions/WorkspaceNavigationActions.tsx
@@ -31,6 +31,11 @@ export function WorkspaceNavigationDropdown(context: NavigationContext) {
                 icon={`git-branch.svg`}
             />
             <List.Dropdown.Item
+                title="Tags"
+                value="tags"
+                icon={Icon.Tag}
+            />
+            <List.Dropdown.Item
                 title="Remotes"
                 value="remotes"
                 keywords={["origin"]}
@@ -47,12 +52,6 @@ export function WorkspaceNavigationDropdown(context: NavigationContext) {
                 value="files"
                 keywords={["history", "ls-files", "workspace", "project"]}
                 icon={Icon.Clock}
-            />
-            <List.Dropdown.Item
-                title="Tags"
-                value="tags"
-                keywords={["release", "refs/tags"]}
-                icon={Icon.Tag}
             />
         </List.Dropdown>
     );
@@ -81,27 +80,28 @@ export function WorkspaceNavigationActions(context: NavigationContext & Reposito
                     shortcut={{ modifiers: ["cmd"], key: "3" }}
                 />
                 <Action
+                    title="Go to Tags"
+                    onAction={() => context.navigateTo("tags")}
+                    icon={Icon.Tag}
+                    shortcut={{ modifiers: ["cmd"], key: "4" }}
+                />
+                <Action
                     title="Go to Remotes"
                     onAction={() => context.navigateTo("remotes")}
                     icon={Icon.Network}
-                    shortcut={{ modifiers: ["cmd"], key: "4" }}
+                    shortcut={{ modifiers: ["cmd"], key: "5" }}
                 />
                 <Action
                     title="Go to Stash"
                     onAction={() => context.navigateTo("stashes")}
                     icon={Icon.Bookmark}
-                    shortcut={{ modifiers: ["cmd"], key: "5" }}
+                    shortcut={{ modifiers: ["cmd"], key: "6" }}
                 />
                 <Action
                     title="Go to Files"
                     onAction={() => context.navigateTo("files")}
                     icon={Icon.Folder}
                     shortcut={{ modifiers: ["cmd"], key: "0" }}
-                />
-                <Action
-                    title="Go to Tags"
-                    onAction={() => context.navigateTo("tags")}
-                    icon={Icon.Tag}
                 />
             </ActionPanel.Section>
 

--- a/src/hooks/useAiPromptPresets.ts
+++ b/src/hooks/useAiPromptPresets.ts
@@ -1,4 +1,3 @@
-import { AI } from "@raycast/api";
 import { useCachedState } from "@raycast/utils";
 import { nanoid } from "nanoid";
 import { useEffect, useMemo } from "react";
@@ -24,13 +23,10 @@ const DEFAULT_AI_COMMIT_PROMPT = `
 You are a helpful assistant that generates concise, clear Git commit messages.
 
 Analyze the provided git diff and generate a conventional commit message that accurately describes the changes.
-Use conventional commit format:
-\`\`\`example
+- Focus on what changed and why.
+- Use conventional commit format:
 <short title>
 <listed changes>
-\`\`\`
-- Message should be without quotes.
-- Focus on what changed and why.
 `;
 
 

--- a/src/hooks/useGitStash.ts
+++ b/src/hooks/useGitStash.ts
@@ -12,8 +12,9 @@ import { RepositoryContext } from "../open-repository";
 export function useGitStash(gitManager: GitManager): RepositoryContext["stashes"] {
   return useCachedPromise(
     async (repoPath: string) => {
-      const stashList = await gitManager.getStashes();
-      return stashList;
+      const stashes = await gitManager.getStashes();
+      return stashes;
+
     },
     [gitManager.repoPath], // Include repository path for separate cache per repository
     {

--- a/src/hooks/useGitTags.ts
+++ b/src/hooks/useGitTags.ts
@@ -1,43 +1,19 @@
 import { useCachedPromise } from "@raycast/utils";
 import { GitManager } from "../utils/git-manager";
 import { RepositoryContext } from "../open-repository";
-import { Tag } from "../types";
-
-export type TagsState = {
-  local: Tag[];
-  remotes: Record<string, Tag[]>;
-};
 
 /**
- * Hook for fetching and managing Git tags state (local and per-remote grouped).
- * Repository path is included in cache dependencies to ensure separate cache per repository.
+ * Hook for fetching and managing Git tags state.
  */
-export function useGitTags(gitManager: GitManager, remotes?: RepositoryContext["remotes"]["data"]): {
-  data: TagsState;
-  isLoading: boolean;
-  error: Error | undefined;
-  revalidate: () => void;
-} {
+export function useGitTags(gitManager: GitManager): RepositoryContext["tags"] {
   return useCachedPromise(
-    async (repoPath: string, remotesNames: string[]) => {
-      const [local, ...remotesLists] = await Promise.all<unknown>([
-        gitManager.getLocalTags(),
-        ...remotesNames.map((name) => gitManager.getRemoteTags(name)),
-      ]) as [Tag[], ...Tag[][]];
-
-      const groupedRemotes = remotesNames.reduce<Record<string, Tag[]>>((acc, name, index) => {
-        acc[name] = remotesLists[index] || [];
-        return acc;
-      }, {});
-
-      return {
-        local,
-        remotes: groupedRemotes,
-      } as TagsState;
+    async (repoPath: string) => {
+      const tags = gitManager.getTags()
+      return tags
     },
-    [gitManager.repoPath, JSON.stringify(Object.keys(remotes || {}))],
+    [gitManager.repoPath], // Include repository path for separate cache per repository
     {
-      initialData: { local: [], remotes: {} },
+      initialData: [],
     }
-  ) as unknown as { data: TagsState; isLoading: boolean; error: Error | undefined; revalidate: () => void };
+  ) as RepositoryContext["tags"];
 }

--- a/src/hooks/useGitTags.ts
+++ b/src/hooks/useGitTags.ts
@@ -1,0 +1,43 @@
+import { useCachedPromise } from "@raycast/utils";
+import { GitManager } from "../utils/git-manager";
+import { RepositoryContext } from "../open-repository";
+import { Tag } from "../types";
+
+export type TagsState = {
+  local: Tag[];
+  remotes: Record<string, Tag[]>;
+};
+
+/**
+ * Hook for fetching and managing Git tags state (local and per-remote grouped).
+ * Repository path is included in cache dependencies to ensure separate cache per repository.
+ */
+export function useGitTags(gitManager: GitManager, remotes?: RepositoryContext["remotes"]["data"]): {
+  data: TagsState;
+  isLoading: boolean;
+  error: Error | undefined;
+  revalidate: () => void;
+} {
+  return useCachedPromise(
+    async (repoPath: string, remotesNames: string[]) => {
+      const [local, ...remotesLists] = await Promise.all<unknown>([
+        gitManager.getLocalTags(),
+        ...remotesNames.map((name) => gitManager.getRemoteTags(name)),
+      ]) as [Tag[], ...Tag[][]];
+
+      const groupedRemotes = remotesNames.reduce<Record<string, Tag[]>>((acc, name, index) => {
+        acc[name] = remotesLists[index] || [];
+        return acc;
+      }, {});
+
+      return {
+        local,
+        remotes: groupedRemotes,
+      } as TagsState;
+    },
+    [gitManager.repoPath, JSON.stringify(Object.keys(remotes || {}))],
+    {
+      initialData: { local: [], remotes: {} },
+    }
+  ) as unknown as { data: TagsState; isLoading: boolean; error: Error | undefined; revalidate: () => void };
+}

--- a/src/open-repository.tsx
+++ b/src/open-repository.tsx
@@ -15,6 +15,7 @@ import { useGitStatus } from "./hooks/useGitStatus";
 import { GitView, BranchesState, StatusState, Stash, Commit, ListPagination, DetachedHead } from "./types";
 import { useGitRemotes } from "./hooks/useGitRemotes";
 import RemotesView from "./commands/views/RemotesView";
+import TagsView from "./commands/views/TagsView";
 import { Branch, Remote } from "./types";
 import { GitManager } from "./utils/git-manager";
 
@@ -142,6 +143,10 @@ export default function OpenRepository({ arguments: args }: { arguments: Argumen
     case "stashes":
       return (
         <StashesView {...rootContext} />
+      );
+    case "tags":
+      return (
+        <TagsView {...rootContext} />
       );
     default:
       setCurrentView("branches");

--- a/src/open-repository.tsx
+++ b/src/open-repository.tsx
@@ -12,12 +12,13 @@ import { useGitBranches } from "./hooks/useGitBranches";
 import { useGitCommits } from "./hooks/useGitCommits";
 import { useGitStash } from "./hooks/useGitStash";
 import { useGitStatus } from "./hooks/useGitStatus";
-import { GitView, BranchesState, StatusState, Stash, Commit, ListPagination, DetachedHead } from "./types";
+import { GitView, BranchesState, StatusState, Stash, Commit, ListPagination, DetachedHead, Tag } from "./types";
 import { useGitRemotes } from "./hooks/useGitRemotes";
 import RemotesView from "./commands/views/RemotesView";
 import TagsView from "./commands/views/TagsView";
 import { Branch, Remote } from "./types";
 import { GitManager } from "./utils/git-manager";
+import { useGitTags } from "./hooks/useGitTags";
 
 interface Arguments {
   path: string;
@@ -37,6 +38,12 @@ export type RepositoryContext = {
   };
   branches: {
     data: BranchesState;
+    isLoading: boolean;
+    error: Error | undefined;
+    revalidate: () => void;
+  };
+  tags: {
+    data: Tag[];
     isLoading: boolean;
     error: Error | undefined;
     revalidate: () => void;
@@ -103,6 +110,7 @@ export default function OpenRepository({ arguments: args }: { arguments: Argumen
   // Shared data hooks lifted to the top-level to persist across view switches
   const remotesContext = useGitRemotes(gitManager);
   const branchesContext = useGitBranches(gitManager);
+  const tagsContext = useGitTags(gitManager);
   const commitsContext = useGitCommits(gitManager, branchesContext.data);
   const stashesContext = useGitStash(gitManager);
   const statusContext = useGitStatus(gitManager);
@@ -114,6 +122,7 @@ export default function OpenRepository({ arguments: args }: { arguments: Argumen
     commits: commitsContext,
     stashes: stashesContext,
     status: statusContext,
+    tags: tagsContext,
     currentView,
     navigateTo: setCurrentView,
   };
@@ -132,21 +141,21 @@ export default function OpenRepository({ arguments: args }: { arguments: Argumen
       return (
         <BranchesView {...rootContext} />
       );
+    case "tags":
+      return (
+        <TagsView {...rootContext} />
+      );
     case "remotes":
       return (
         <RemotesView {...rootContext} />
-      );
-    case "files":
-      return (
-        <FilesView {...rootContext} />
       );
     case "stashes":
       return (
         <StashesView {...rootContext} />
       );
-    case "tags":
+    case "files":
       return (
-        <TagsView {...rootContext} />
+        <FilesView {...rootContext} />
       );
     default:
       setCurrentView("branches");

--- a/src/types/git-types.ts
+++ b/src/types/git-types.ts
@@ -244,6 +244,16 @@ export interface Tag {
 }
 
 /**
+ * Represents tags grouped by location.
+ */
+export interface TagsState {
+  /** Local tags in the repository. */
+  local: Tag[];
+  /** Remote tags grouped by remote name. */
+  remotes: Record<string, Tag[]>;
+}
+
+/**
  * Represents per-file change statistics (insertions/deletions).
  */
 export interface FileChangeStats {

--- a/src/types/git-types.ts
+++ b/src/types/git-types.ts
@@ -241,16 +241,10 @@ export interface Tag {
   commitHash: string;
   /** The date the tag was created. */
   date?: Date;
-}
-
-/**
- * Represents tags grouped by location.
- */
-export interface TagsState {
-  /** Local tags in the repository. */
-  local: Tag[];
-  /** Remote tags grouped by remote name. */
-  remotes: Record<string, Tag[]>;
+  /** The author of the tag. */
+  author?: string;
+  /** The author's email. */
+  authorEmail?: string;
 }
 
 /**

--- a/src/types/git-types.ts
+++ b/src/types/git-types.ts
@@ -286,6 +286,9 @@ export enum MergeMode {
   NO_COMMIT = "no-commit",
 }
 
+/**
+ * Represents the scope of a patch.
+ */
 export enum PatchScope {
   ALL = "all",
   STAGED = "staged",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,6 +17,8 @@ export interface Preferences {
   commitsPerPage: string;
   /** Maximum number of branches to load per pagination page. */
   maxBranchesToLoad: string;
+  /** Maximum number of tags to load in tags list. */
+  maxTagsToLoad: string;
   /** Automatically generate a commit message using AI when opening the commit view. */
   autoGenerateCommitMessage: boolean;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,7 +3,7 @@ import { Application } from "@raycast/api";
 // Export all types from modules
 export * from "./git-types";
 
-export type GitView = "branches" | "status" | "commits" | "files" | "stashes" | "remotes";
+export type GitView = "branches" | "status" | "commits" | "files" | "stashes" | "remotes" | "tags";
 
 /**
  * User preferences for the Git Client extension.

--- a/src/utils/git-manager.ts
+++ b/src/utils/git-manager.ts
@@ -1037,6 +1037,10 @@ __REBASE_TODO__
    * Gets a list of all stashes.
    */
   async getStashes(): Promise<Stash[]> {
+    // Check if stash reference exists before proceeding
+    const stashPath = join(this.repoPath, '.git', 'refs', 'stash');
+    if (!existsSync(stashPath)) return [];
+
     const stashList = await this.git.raw(["reflog", "show", "refs/stash", "--date=iso-strict", "--format='òòòòòò %H ò %ad ò %gs ò %gd ò %gN ò %gE òò'"]);
 
     return stashList.trim()
@@ -1103,7 +1107,7 @@ __REBASE_TODO__
    * Checks out a tag (detached HEAD state).
    */
   async checkoutTag(tagName: string): Promise<void> {
-    await this.git.checkout([`tags/${tagName}`]);
+    await this.git.checkout([`refs/tags/${tagName}`]);
   }
 
   /**
@@ -1239,58 +1243,38 @@ __REBASE_TODO__
   /**
    * Gets a list of all local tags with basic metadata.
    */
-  async getLocalTags(): Promise<Tag[]> {
+  async getTags(): Promise<Tag[]> {
+    const maxTagsToLoad = parseInt(
+      getPreferenceValues<Preferences>().maxTagsToLoad
+    );
+
     // Use for-each-ref to retrieve tag name, object (commit) and metadata where available
     // %(objectname) returns the referenced object (commit for lightweight tags or tag object for annotated)
     // %(*objectname) dereferences annotated tags to the target object (commit)
-    const format = "%(refname:short)|%(objectname)|%(*objectname)|%(taggerdate:iso-strict)|%(subject)";
-    const raw = await this.git.raw(["for-each-ref", "refs/tags", `--format=${format}`]);
+    const format = "%(refname:short)|%(objectname)|%(*objectname)|%(taggerdate:iso-strict)|%(subject)|%(taggername)|%(taggeremail)";
+    const raw = await this.git.raw([
+      "for-each-ref",
+      "refs/tags",
+      "--sort=-creatordate",
+      `--format=${format}`,
+      `--count=${maxTagsToLoad}`
+    ]);
 
     return raw
       .trim()
       .split("\n")
       .filter((line) => !!line.trim())
       .map((line) => {
-        const [name, objectName, peeledObjectName, dateStr, subject] = line.split("|");
-        const commitHash = (peeledObjectName || objectName || "").trim();
-        const message = subject?.trim() || undefined;
+        const [name, objectName, dereferencedObjectName, dateStr, subject, authorStr, authorEmailStr] = line.split("|");
+        // For annotated tags, the object name is the tag object, and the peeled object name is the commit object
+        const commitHash = (dereferencedObjectName || objectName || "").trim();
+        const message = subject?.trim();
         const date = dateStr && dateStr.trim() ? new Date(dateStr.trim()) : undefined;
+        const author = authorStr?.trim();
+        const authorEmail = authorEmailStr?.trim().replace(/[<>]/g, '');
 
-        return { name, commitHash, message, date } as Tag;
+        return { name, commitHash, message, date, author, authorEmail } as Tag;
       });
-  }
-
-  /**
-   * Gets a list of remote tags for the specified remote.
-   * Only commit hashes and names are available via ls-remote.
-   */
-  async getRemoteTags(remote: string): Promise<Tag[]> {
-    const raw = await this.git.raw(["ls-remote", "--tags", remote]);
-
-    // Build a map of tag -> commit hash, preferring peeled ^{} entries when present
-    const tagToCommit: Record<string, string> = {};
-
-    for (const line of raw.trim().split("\n")) {
-      const parts = line.trim().split(/\s+/);
-      if (parts.length < 2) continue;
-      const hash = parts[0];
-      const ref = parts[1];
-
-      const match = ref.match(/^refs\/tags\/(.+?)(\^\{\})?$/);
-      if (!match) continue;
-
-      const tagName = match[1];
-      const isPeeled = !!match[2];
-
-      if (isPeeled) {
-        tagToCommit[tagName] = hash; // Prefer peeled commit hash
-      } else if (!tagToCommit[tagName]) {
-        // Set only if not already set by peeled entry
-        tagToCommit[tagName] = hash;
-      }
-    }
-
-    return Object.entries(tagToCommit).map(([name, commitHash]) => ({ name, commitHash }));
   }
 
   /**
@@ -1304,8 +1288,6 @@ __REBASE_TODO__
    * Pushes tags to remote with optional delete flag.
    */
   async pushTag(tagName: string, remote: string, deleteTag: boolean = false): Promise<void> {
-    // Use provided remote name or get the default remote
-
     if (deleteTag) {
       // Delete tag from remote using --delete flag
       await this.git.push(remote, tagName, ["--delete"]);

--- a/src/utils/git-manager.ts
+++ b/src/utils/git-manager.ts
@@ -993,14 +993,23 @@ __REBASE_TODO__
   }
 
   /**
-   * Creates a stash with an optional message.
+   * Creates a stash with an optional message and scope flags.
    */
-  async stash(message?: string): Promise<void> {
-    if (message) {
-      await this.git.stash(["push", "-m", message]);
-    } else {
-      await this.git.stash();
+  async stash(message: string, scope?: PatchScope): Promise<void> {
+    const args: string[] = [];
+
+    if (scope === PatchScope.STAGED) {
+      args.push("--staged");
     }
+
+    if (scope === PatchScope.UNSTAGED) {
+      args.push("--keep-index");
+      args.push("--include-untracked");
+    }
+
+    args.push("-m", message);
+
+    await this.git.stash(["push", ...args]);
   }
 
   /**

--- a/src/utils/git-manager.ts
+++ b/src/utils/git-manager.ts
@@ -1037,15 +1037,46 @@ __REBASE_TODO__
    * Gets a list of all stashes.
    */
   async getStashes(): Promise<Stash[]> {
-    const stashList = await this.git.stashList();
+    const stashList = await this.git.raw(["reflog", "show", "refs/stash", "--date=iso-strict", "--format='òòòòòò %H ò %ad ò %gs ò %gd ò %gN ò %gE òò'"]);
 
-    return stashList.all.map((stash) => ({
-      message: stash.message.replace(/^On [^:]+: /, ""),
-      hash: stash.hash,
-      date: new Date(stash.date),
-      author: stash.author_name,
-      authorEmail: stash.author_email,
-    }));
+    return stashList.trim()
+      .split("\n")
+      .map((rawLine) => {
+        const regex = /^'òòòòòò (?<hash>[0-9a-f]+) ò (?<date>[^ò]+) ò (?<message>[^ò]+) ò stash@\{[^}]+\} ò (?<author>[^ò]+) ò (?<authorEmail>[^ò]+) òò'$/;
+        const stash = rawLine.trim().match(regex);
+
+        if (!stash || !stash?.groups) {
+          return undefined;
+        }
+
+        return {
+          message: stash.groups.message,
+          hash: stash.groups.hash,
+          date: new Date(stash.groups.date),
+          author: stash.groups.author,
+          authorEmail: stash.groups.authorEmail,
+        } as Stash;
+      })
+      .filter((stash) => stash !== undefined);
+  }
+
+  /**
+   * Renames a stash entry by index using drop -> store flow.
+   * The implementation follows the technique described here:
+   * - obtain the stash commit hash
+   * - drop the stash reference
+   * - store it back with a new message
+   */
+  async renameStash(
+    index: number,
+    stash: Stash,
+    newMessage: string
+  ): Promise<void> {
+    // Drop original stash reference
+    await this.git.stash(["drop", `stash@{${index}}`]);
+
+    // Store back with the new message
+    await this.git.stash(["store", "-m", newMessage, stash.hash]);
   }
 
   /**

--- a/src/utils/git-manager.ts
+++ b/src/utils/git-manager.ts
@@ -2,7 +2,7 @@ import { CleanOptions, DiffNameStatus, DiffResult, DiffResultBinaryFile, DiffRes
 import { showToast, Toast, getPreferenceValues, Alert, confirmAlert } from "@raycast/api";
 import { readFileSync, writeFileSync, mkdtempSync, chmodSync, rmSync, existsSync } from "fs";
 import { tmpdir } from "os";
-import { Branch, FileStatus, Commit, Stash, BranchesState, DetachedHead, CommitFileChange, Preferences, RebasePlanItem, FileChangeStats, StatusState, ConflictState, MergeMode, PatchScope, RepositoryCloningProcess, RepositoryCloningState } from "../types";
+import { Branch, FileStatus, Commit, Stash, BranchesState, DetachedHead, CommitFileChange, Preferences, RebasePlanItem, FileChangeStats, StatusState, ConflictState, MergeMode, PatchScope, RepositoryCloningProcess, RepositoryCloningState, Tag } from "../types";
 import { basename, join } from "path";
 import { promises as fs } from "fs";
 import { showFailureToast } from "@raycast/utils";
@@ -1091,6 +1091,22 @@ __REBASE_TODO__
   }
 
   /**
+   * Renames a tag locally by creating a new tag pointing to the same object and deleting the old one.
+   */
+  async renameTag(oldName: string, newName: string): Promise<void> {
+    // Create new tag pointing to the same object as oldName, then delete old tag
+    await this.git.raw(["tag", newName, oldName]);
+    await this.git.raw(["tag", "-d", oldName]);
+  }
+
+  /**
+   * Checks out a tag (detached HEAD state).
+   */
+  async checkoutTag(tagName: string): Promise<void> {
+    await this.git.checkout([`tags/${tagName}`]);
+  }
+
+  /**
    * Gets the absolute path to a file.
    */
   private getAbsolutePath(relativePath: string): string {
@@ -1221,11 +1237,60 @@ __REBASE_TODO__
   }
 
   /**
-   * Gets a list of all tags.
+   * Gets a list of all local tags with basic metadata.
    */
-  async getTags(): Promise<string[]> {
-    const tags = await this.git.tags();
-    return tags.all;
+  async getLocalTags(): Promise<Tag[]> {
+    // Use for-each-ref to retrieve tag name, object (commit) and metadata where available
+    // %(objectname) returns the referenced object (commit for lightweight tags or tag object for annotated)
+    // %(*objectname) dereferences annotated tags to the target object (commit)
+    const format = "%(refname:short)|%(objectname)|%(*objectname)|%(taggerdate:iso-strict)|%(subject)";
+    const raw = await this.git.raw(["for-each-ref", "refs/tags", `--format=${format}`]);
+
+    return raw
+      .trim()
+      .split("\n")
+      .filter((line) => !!line.trim())
+      .map((line) => {
+        const [name, objectName, peeledObjectName, dateStr, subject] = line.split("|");
+        const commitHash = (peeledObjectName || objectName || "").trim();
+        const message = subject?.trim() || undefined;
+        const date = dateStr && dateStr.trim() ? new Date(dateStr.trim()) : undefined;
+
+        return { name, commitHash, message, date } as Tag;
+      });
+  }
+
+  /**
+   * Gets a list of remote tags for the specified remote.
+   * Only commit hashes and names are available via ls-remote.
+   */
+  async getRemoteTags(remote: string): Promise<Tag[]> {
+    const raw = await this.git.raw(["ls-remote", "--tags", remote]);
+
+    // Build a map of tag -> commit hash, preferring peeled ^{} entries when present
+    const tagToCommit: Record<string, string> = {};
+
+    for (const line of raw.trim().split("\n")) {
+      const parts = line.trim().split(/\s+/);
+      if (parts.length < 2) continue;
+      const hash = parts[0];
+      const ref = parts[1];
+
+      const match = ref.match(/^refs\/tags\/(.+?)(\^\{\})?$/);
+      if (!match) continue;
+
+      const tagName = match[1];
+      const isPeeled = !!match[2];
+
+      if (isPeeled) {
+        tagToCommit[tagName] = hash; // Prefer peeled commit hash
+      } else if (!tagToCommit[tagName]) {
+        // Set only if not already set by peeled entry
+        tagToCommit[tagName] = hash;
+      }
+    }
+
+    return Object.entries(tagToCommit).map(([name, commitHash]) => ({ name, commitHash }));
   }
 
   /**
@@ -1248,6 +1313,34 @@ __REBASE_TODO__
       // Push specific tag to remote
       await this.git.push(remote, tagName);
     }
+  }
+
+  /**
+   * Returns a single commit by hash with parsed metadata and changed files.
+   */
+  async getCommitByHash(commitHash: string): Promise<Commit | null> {
+    const log = await this.git.log(["--max-count=1", "--name-status", "--decorate=full", commitHash]);
+
+    if (!log.latest) return null;
+
+    const commit = log.latest;
+    const changedFiles = this.parseCommitChangedFiles(commit.diff!);
+    const parsedRefs = this.parseCommitRefs(commit.refs);
+
+    return {
+      hash: commit.hash,
+      shortHash: commit.hash.substring(0, 7),
+      message: commit.message,
+      body: commit.body,
+      author: commit.author_name,
+      authorEmail: commit.author_email,
+      date: new Date(commit.date),
+      localBranches: parsedRefs.localBranches,
+      remoteBranches: parsedRefs.remoteBranches,
+      tags: parsedRefs.tags,
+      currentBranchName: parsedRefs.currentBranchName,
+      changedFiles,
+    } as Commit;
   }
 
   /**


### PR DESCRIPTION
Add a new 'Tags' view to the repository interface to enable comprehensive Git tag management.

---
<a href="https://cursor.com/background-agent?bcId=bc-452e9bf1-6681-413c-a46e-91558f505e2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-452e9bf1-6681-413c-a46e-91558f505e2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

