### PR TITLE
feat(ai-presets): add adaptive "Automatic" commit message preset

### DIFF
--- a/src/components/views/CommitMessageView.tsx
+++ b/src/components/views/CommitMessageView.tsx
@@ -5,6 +5,11 @@ import { showToast, Toast, getPreferenceValues, confirmAlert, environment, useNa
 import { AI } from "@raycast/api";
 import { Action, ActionPanel, Form, Icon, Alert } from "@raycast/api";
 import { AiPromptPreset, useAiPromptPresets } from "../../hooks/useAiPromptPresets";
+import {
+  AUTOMATIC_PRESET_ID,
+  buildAutomaticSystemPrompt,
+  resolveCommitMessagePattern,
+} from "../../utils/commit-pattern";
 import { AiMessagePresetEditorForm } from "../../manage-ai-message-prompts";
 import { RemoteHostIcon } from "../icons/RemoteHostIcons";
 import { RepositoryContext } from "../../open-repository";
@@ -63,6 +68,21 @@ export function CommitMessageForm(context: RepositoryContext & { commit?: Commit
   const generateCommitMessage = async (presetPrompt: AiPromptPreset) => {
     try {
       setIsGenerating(true);
+      await showToast({
+        style: Toast.Style.Animated,
+        title: "Generating commit message...",
+        message: "This may take a few seconds.",
+      });
+
+      const model = presetPrompt.model ? AI.Model[presetPrompt.model as keyof typeof AI.Model] : undefined;
+
+      // The "Automatic" preset derives its system prompt from the repository's
+      // own commit style, inferred from the last non-merge commits.
+      let systemPrompt = presetPrompt.prompt.trim();
+      if (presetPrompt.id === AUTOMATIC_PRESET_ID) {
+        const pattern = await resolveCommitMessagePattern(context.gitManager, model);
+        systemPrompt = buildAutomaticSystemPrompt(pattern);
+      }
 
       // Get staged changes diff
       const diff = await context.gitManager.getDiff();
@@ -72,7 +92,7 @@ export function CommitMessageForm(context: RepositoryContext & { commit?: Commit
       }
 
       // Form a more structured and readable prompt for AI generation of commit message using selected preset
-      const promptParts = [presetPrompt.prompt.trim(), ""];
+      const promptParts = [systemPrompt, ""];
 
       if (!context.commit) {
         promptParts.push(
@@ -109,16 +129,9 @@ export function CommitMessageForm(context: RepositoryContext & { commit?: Commit
         });
       }
 
-      const model = presetPrompt.model ? AI.Model[presetPrompt.model as keyof typeof AI.Model] : undefined;
-
       const aiResponse = AI.ask(prompt, {
         creativity: "none",
         model: model,
-      });
-      await showToast({
-        style: Toast.Style.Animated,
-        title: "Generating commit message...",
-        message: "This may take a few seconds.",
       });
       setDraftMessage(await aiResponse);
 

--- a/src/hooks/useAiPromptPresets.ts
+++ b/src/hooks/useAiPromptPresets.ts
@@ -1,5 +1,6 @@
 import { nanoid } from "nanoid";
 import { useStorage } from "./useStorage";
+import { AUTOMATIC_PRESET_ID } from "../utils/commit-pattern";
 
 /**
  * Represents an AI commit message prompt preset.
@@ -26,6 +27,23 @@ export interface AiPromptPresetsData {
   /** ID of the default preset */
   defaultPresetId: string;
 }
+
+/**
+ * Adaptive preset that infers the repository's commit message style from recent
+ * history and generates a new message matching it. Generation for this preset is
+ * handled specially in the commit message form (see `AUTOMATIC_PRESET_ID`).
+ */
+const AUTOMATIC_MESSAGE_PROMPT: AiPromptPreset = {
+  id: AUTOMATIC_PRESET_ID,
+  name: "Automatic",
+  icon: "🤖",
+  prompt: `
+Automatically detect the commit message style used in the repository by analyzing the last 10 non-merge commits, then generate a new commit message that matches that style.
+
+This preset adapts to whatever convention the repository already uses (Conventional Commits, gitmoji, plain text, etc.). The detected style is cached for a short time to keep generation fast.
+`.trim(),
+  model: "Google_Gemini_2.5_Flash",
+};
 
 /**
  * Default prompt used when there are no saved presets.
@@ -117,11 +135,11 @@ Output only the commit message, no markdown or extra text.
  */
 export function useAiPromptPresets() {
   const [data, setData] = useStorage<AiPromptPresetsData>("ai-prompt-presets", {
-    presets: [CONVENTIONAL_MESSAGE_PROMPT, GITMOJI_MESSAGE_PROMPT, MINIMALIST_MESSAGE_PROMPT],
-    defaultPresetId: CONVENTIONAL_MESSAGE_PROMPT.id,
+    presets: [AUTOMATIC_MESSAGE_PROMPT, CONVENTIONAL_MESSAGE_PROMPT, GITMOJI_MESSAGE_PROMPT, MINIMALIST_MESSAGE_PROMPT],
+    defaultPresetId: AUTOMATIC_MESSAGE_PROMPT.id,
   });
 
-  const defaultPreset = data.presets.find((p) => p.id === data.defaultPresetId) ?? CONVENTIONAL_MESSAGE_PROMPT;
+  const defaultPreset = data.presets.find((p) => p.id === data.defaultPresetId) ?? AUTOMATIC_MESSAGE_PROMPT;
   const otherPresets = data.presets.filter((p) => p.id !== data.defaultPresetId);
 
   const addPreset = (name: string, prompt: string, model?: string) => {

--- a/src/utils/commit-pattern.ts
+++ b/src/utils/commit-pattern.ts
@@ -1,0 +1,126 @@
+import { AI, Cache, environment } from "@raycast/api";
+import { GitManager } from "./git-manager";
+
+/** Stable identifier of the built-in "Automatic" AI commit message preset. */
+export const AUTOMATIC_PRESET_ID = "automatic-style";
+
+/** Number of recent non-merge commits analyzed to infer the message style. */
+const RECENT_COMMITS_TO_ANALYZE = 10;
+
+/** Time-to-live for a cached commit style description, in milliseconds. */
+const PATTERN_CACHE_TTL_MS = 5 * 60 * 1000;
+
+/** Namespaced cache for storing resolved commit style descriptions per repository. */
+const patternCache = new Cache({ namespace: "automatic-commit-pattern" });
+
+/**
+ * Cached commit style description together with its expiration timestamp.
+ */
+interface CachedPattern {
+  /** AI-generated description of the repository commit message style. */
+  pattern: string;
+  /** Unix epoch (ms) after which the cached pattern is considered stale. */
+  expiresAt: number;
+}
+
+/**
+ * Instruction used to make the AI infer a reusable commit message style guide
+ * from a list of recent commit messages.
+ */
+const PATTERN_DETECTION_PROMPT = `
+You are analyzing the commit history of a Git repository to learn its commit message conventions.
+
+Study the recent commit messages below and produce a concise style guide that another AI could follow to write a NEW commit message that fits seamlessly into this history.
+
+Describe, when applicable:
+- The title format (prefixes/types, scopes, casing, punctuation, gitmoji/emoji usage, approximate max length).
+- The mood/voice (e.g. imperative vs past tense).
+- Whether and how a body is used (bullet points, line wrapping, blank line after title).
+- Any recurring patterns (issue/ticket references, trailers, etc.).
+
+Output ONLY the style guide as plain instructions. Do not write an example commit message and do not add commentary.
+`.trim();
+
+/**
+ * Fallback style guide used when the repository has no prior commit history to learn from.
+ */
+const FALLBACK_PATTERN = `
+Write a clear, conventional commit message.
+
+- Use a short imperative title under 50 characters ("add" not "added").
+- Optionally add a body with bullet points describing notable changes, separated from the title by a blank line.
+- Focus on WHAT changed.
+`.trim();
+
+/**
+ * Builds the system prompt used to generate a commit message that matches the
+ * repository's inferred commit style.
+ * @param pattern - The resolved commit style description.
+ */
+export function buildAutomaticSystemPrompt(pattern: string): string {
+  return [
+    "You are a Git commit message generator.",
+    "Analyze the provided git diff and write a commit message that strictly follows the repository's commit message style described below.",
+    "",
+    "--------------------",
+    "REPOSITORY COMMIT STYLE:",
+    "--------------------",
+    pattern.trim(),
+    "--------------------",
+    "",
+    "Output only the commit message, no markdown fences or extra text.",
+  ].join("\n");
+}
+
+/**
+ * Resolves a description of the commit message style used in the repository by
+ * analyzing recent non-merge commits via AI. Results are cached per repository
+ * with a short TTL to avoid repeated AI calls on consecutive generations.
+ *
+ * @param gitManager - Git manager bound to the target repository.
+ * @param model - Optional AI model used for the analysis.
+ * @returns A style guide describing the repository's commit message conventions.
+ */
+export async function resolveCommitMessagePattern(gitManager: GitManager, model?: AI.Model): Promise<string> {
+  const cacheKey = gitManager.repoPath;
+
+  const cachedRaw = patternCache.get(cacheKey);
+  if (cachedRaw) {
+    try {
+      const cached = JSON.parse(cachedRaw) as CachedPattern;
+      if (cached.expiresAt > Date.now() && cached.pattern.trim().length > 0) {
+        return cached.pattern;
+      }
+    } catch {
+      // Ignore malformed cache entries and recompute the pattern below.
+    }
+  }
+
+  const messages = await gitManager.getRecentCommitMessages(RECENT_COMMITS_TO_ANALYZE);
+
+  // Without prior history there is no style to learn from; use a sensible default.
+  if (messages.length === 0) {
+    return FALLBACK_PATTERN;
+  }
+
+  const prompt = [
+    PATTERN_DETECTION_PROMPT,
+    "",
+    "--------------------",
+    "RECENT COMMIT MESSAGES:",
+    "--------------------",
+    ...messages.map((message, index) => `Commit ${index + 1}:\n${message}\n`),
+    "--------------------",
+  ].join("\n");
+
+  if (environment.isDevelopment) {
+    console.warn("[Automatic Preset] Resolving commit style from recent messages...");
+  }
+
+  const pattern = (await AI.ask(prompt, { creativity: "none", model })).trim();
+
+  const entry: CachedPattern = { pattern, expiresAt: Date.now() + PATTERN_CACHE_TTL_MS };
+  patternCache.set(cacheKey, JSON.stringify(entry));
+
+  return pattern;
+}

--- a/src/utils/git-manager.ts
+++ b/src/utils/git-manager.ts
@@ -639,6 +639,23 @@ export class GitManager {
   }
 
   /**
+   * Gets the full messages (subject and body) of the most recent non-merge commits.
+   * Useful for analyzing the commit message style used in the repository.
+   * @param count Maximum number of commits to read.
+   * @returns List of trimmed commit messages ordered from newest to oldest.
+   */
+  async getRecentCommitMessages(count: number): Promise<string[]> {
+    // Unlikely-to-appear separator used to split individual commit messages.
+    const separator = "òòòòòò";
+    const raw = await this.git.raw(["log", "--no-merges", `--max-count=${count}`, `--pretty=format:%B${separator}`]);
+
+    return raw
+      .split(separator)
+      .map((message) => message.trim())
+      .filter((message) => message.length > 0);
+  }
+
+  /**
    * Gets the commit history with optional offset for pagination.
    * @param branch Branch name to get commits from (optional)
    * @param page Page number for pagination (optional, default 0)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new AI commit message preset named **Automatic** that adapts to the repository's existing commit style instead of using a fixed prompt.

When generating with this preset:
1. Reads the messages of the last 10 non-merge commits.
2. Uses `AI.ask` to infer a reusable description of the repository's commit message style/pattern.
3. Generates a new commit message (from the staged diff) that matches that detected style.

The preset is set as the **default**, so it powers the first `Generate Message` action in the commit message form.

The resolved style description is stored in `Cache` (namespaced per repository) with a short TTL (5 min) to avoid repeated AI analysis on consecutive generations.

## Changes
- `src/utils/git-manager.ts`: add `getRecentCommitMessages(count)` to read recent non-merge commit messages.
- `src/utils/commit-pattern.ts` (new): infer the commit style via AI, cache it in `Cache` with a short TTL, and build the generation system prompt. Falls back to a sensible default when there is no commit history.
- `src/hooks/useAiPromptPresets.ts`: add the `Automatic` preset and make it the default.
- `src/components/views/CommitMessageView.tsx`: for the Automatic preset, resolve the system prompt from the detected style before generation.

## Testing
- `npm exec ray build` — builds successfully.
- `npm exec ray lint` — passes.
- Verified `git log --no-merges --max-count=10 --pretty=format:"%B<sep>"` output and message parsing on this repository.

> Note: GUI testing inside Raycast isn't available in the Linux cloud VM (the extension and `AI.ask` require the Raycast macOS app), so verification is limited to build, lint, and git command validation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d623ba4d-ca93-4aa0-b5c0-c8a3348a18c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d623ba4d-ca93-4aa0-b5c0-c8a3348a18c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

